### PR TITLE
Simplify .gitignore by removing overbroad '*log*' pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ models/
 *.png
 *.jpg
 *.srt
-*log*
 
 # Development & Tools
 .vscode/


### PR DESCRIPTION
### Resolution

The single focused change from this PR has been applied directly to the current `main` rather than merging the stale branch.

- removed the overbroad `*log*` ignore pattern
- retained the explicit `*.log`, `logs/`, and other runtime ignore rules
- canonical main commit: `d49fa372bcf25e76e144bb934cd3915cbdd6b650`
- main CI: https://github.com/KAFKA2306/yt3/actions/runs/31648583338

This PR is superseded by the current-main fix and is closed unmerged.