### PR TITLE
feat: add code-only movie generation CLI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,6 +74,16 @@ tasks:
     desc: "Batch publish existing runs-nlm videos"
     cmds: ["bun --env-file=config/.env src/scripts/post_nlm_videos.ts"]
 
+  movie:generate:
+    desc: "Generate and concatenate scene videos from a JSON plan (PLAN=...)"
+    cmds:
+      - |
+        if [ -z "{{.PLAN}}" ]; then
+          echo "PLAN is required" >&2
+          exit 2
+        fi
+        bun src/scripts/generate_movie.ts --plan "{{.PLAN}}" {{.CLI_ARGS}}
+
   movie:status:
     desc: "Report movie receipt status without changing state"
     cmds: ["bun src/scripts/movie_status.ts"]

--- a/src/scripts/generate_movie.ts
+++ b/src/scripts/generate_movie.ts
@@ -145,11 +145,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 			buildGeneratorCommand(plan, scene, scenePaths[index] as string, config),
 		);
 		const concatFile = path.join(sceneDir, "concat.txt");
-		const ffmpegCommand = buildFfmpegCommand(
-			concatFile,
-			output,
-			config.ffmpeg,
-		);
+		const ffmpegCommand = buildFfmpegCommand(concatFile, output, config.ffmpeg);
 
 		if (args.dryRun) {
 			console.log(
@@ -182,9 +178,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 			scenes: plan.scenes.map((scene, index) => ({
 				id: scene.id,
 				output: scenePaths[index],
-				prompt_sha256: createHash("sha256")
-					.update(scene.prompt)
-					.digest("hex"),
+				prompt_sha256: createHash("sha256").update(scene.prompt).digest("hex"),
 			})),
 		};
 		await writeFile(

--- a/src/scripts/generate_movie.ts
+++ b/src/scripts/generate_movie.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+const SceneSchema = z.object({
+	id: z.string().regex(/^[A-Za-z0-9_-]+$/),
+	prompt: z.string().min(1),
+	seed: z.number().int().nonnegative().optional(),
+	fps: z.number().int().positive().optional(),
+	height: z.number().int().positive().optional(),
+	width: z.number().int().positive().optional(),
+	num_frames: z.number().int().positive().optional(),
+	num_inference_steps: z.number().int().positive().optional(),
+	guidance_scale: z.number().finite().optional(),
+});
+
+const MoviePlanSchema = z.object({
+	output: z.string().min(1),
+	model: z.string().min(1).optional(),
+	scenes: z.array(SceneSchema).min(1),
+});
+
+export type MoviePlan = z.infer<typeof MoviePlanSchema>;
+export type MovieScene = z.infer<typeof SceneSchema>;
+
+export interface RuntimeConfig {
+	hfCacheHubRoot: string;
+	python: string;
+	ffmpeg: string;
+}
+
+export function parseMoviePlan(text: string): MoviePlan {
+	return MoviePlanSchema.parse(JSON.parse(text));
+}
+
+export function buildGeneratorCommand(
+	plan: MoviePlan,
+	scene: MovieScene,
+	output: string,
+	config: RuntimeConfig,
+): string[] {
+	const args = [
+		config.python,
+		path.join(config.hfCacheHubRoot, "scripts", "generate_video.py"),
+		"--prompt",
+		scene.prompt,
+		"--output",
+		output,
+		"--registry",
+		path.join(config.hfCacheHubRoot, "models.yaml"),
+		"--project-root",
+		config.hfCacheHubRoot,
+	];
+	if (plan.model) args.push("--model", plan.model);
+	for (const [flag, value] of [
+		["--seed", scene.seed],
+		["--fps", scene.fps],
+		["--height", scene.height],
+		["--width", scene.width],
+		["--num-frames", scene.num_frames],
+		["--num-inference-steps", scene.num_inference_steps],
+		["--guidance-scale", scene.guidance_scale],
+	] as const) {
+		if (value !== undefined) args.push(flag, String(value));
+	}
+	return args;
+}
+
+function quoteConcatPath(value: string): string {
+	return value.replaceAll("'", "'\\''");
+}
+
+export function buildConcatFile(scenePaths: string[]): string {
+	return `${scenePaths.map((scene) => `file '${quoteConcatPath(path.resolve(scene))}'`).join("\n")}\n`;
+}
+
+export function buildFfmpegCommand(concatFile: string, output: string, ffmpeg: string): string[] {
+	return [ffmpeg, "-y", "-f", "concat", "-safe", "0", "-i", concatFile, "-c", "copy", output];
+}
+
+async function run(command: string[]): Promise<void> {
+	const process = Bun.spawn(command, { stdin: "ignore", stdout: "inherit", stderr: "inherit" });
+	const exitCode = await process.exited;
+	if (exitCode !== 0) throw new Error(`command failed (${exitCode}): ${command[0]}`);
+}
+
+function parseArgs(argv: string[]): { planFile: string; dryRun: boolean } {
+	let planFile = "";
+	let dryRun = false;
+	for (let index = 0; index < argv.length; index++) {
+		const value = argv[index];
+		if (value === "--dry-run") dryRun = true;
+		else if (value === "--plan") planFile = argv[++index] ?? "";
+		else throw new Error(`unknown argument: ${value}`);
+	}
+	if (!planFile) throw new Error("--plan is required");
+	return { planFile, dryRun };
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<number> {
+	try {
+		const args = parseArgs(argv);
+		const planFile = path.resolve(args.planFile);
+		const planText = await readFile(planFile, "utf8");
+		const plan = parseMoviePlan(planText);
+		const output = path.resolve(path.dirname(planFile), plan.output);
+		const stem = path.basename(output, path.extname(output));
+		const sceneDir = path.join(path.dirname(output), `${stem}.scenes`);
+		const config: RuntimeConfig = {
+			hfCacheHubRoot: path.resolve(process.env.HF_CACHE_HUB_ROOT ?? "../hf-cache-hub"),
+			python: process.env.VIDEO_PYTHON ?? "python3",
+			ffmpeg: process.env.FFMPEG_BIN ?? "ffmpeg",
+		};
+		const scenePaths = plan.scenes.map((scene, index) =>
+			path.join(sceneDir, `${String(index + 1).padStart(3, "0")}-${scene.id}.mp4`),
+		);
+		const generatorCommands = plan.scenes.map((scene, index) =>
+			buildGeneratorCommand(plan, scene, scenePaths[index] as string, config),
+		);
+		const concatFile = path.join(sceneDir, "concat.txt");
+		const ffmpegCommand = buildFfmpegCommand(concatFile, output, config.ffmpeg);
+
+		if (args.dryRun) {
+			console.log(JSON.stringify({ status: "READY", plan: planFile, output, generatorCommands, ffmpegCommand }, null, 2));
+			return 0;
+		}
+
+		await mkdir(sceneDir, { recursive: true });
+		for (const command of generatorCommands) await run(command);
+		await writeFile(concatFile, buildConcatFile(scenePaths), "utf8");
+		await run(ffmpegCommand);
+
+		const manifest = {
+			schema_version: 1,
+			plan: planFile,
+			plan_sha256: createHash("sha256").update(planText).digest("hex"),
+			output,
+			model: plan.model ?? null,
+			scenes: plan.scenes.map((scene, index) => ({ id: scene.id, output: scenePaths[index], prompt: scene.prompt })),
+		};
+		await writeFile(`${output}.json`, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+		console.log(JSON.stringify({ status: "DONE", output, manifest: `${output}.json` }, null, 2));
+		return 0;
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+if (import.meta.main) process.exit(await main());

--- a/src/scripts/generate_movie.ts
+++ b/src/scripts/generate_movie.ts
@@ -75,14 +75,35 @@ export function buildConcatFile(scenePaths: string[]): string {
 	return `${scenePaths.map((scene) => `file '${quoteConcatPath(path.resolve(scene))}'`).join("\n")}\n`;
 }
 
-export function buildFfmpegCommand(concatFile: string, output: string, ffmpeg: string): string[] {
-	return [ffmpeg, "-y", "-f", "concat", "-safe", "0", "-i", concatFile, "-c", "copy", output];
+export function buildFfmpegCommand(
+	concatFile: string,
+	output: string,
+	ffmpeg: string,
+): string[] {
+	return [
+		ffmpeg,
+		"-y",
+		"-f",
+		"concat",
+		"-safe",
+		"0",
+		"-i",
+		concatFile,
+		"-c",
+		"copy",
+		output,
+	];
 }
 
 async function run(command: string[]): Promise<void> {
-	const process = Bun.spawn(command, { stdin: "ignore", stdout: "inherit", stderr: "inherit" });
-	const exitCode = await process.exited;
-	if (exitCode !== 0) throw new Error(`command failed (${exitCode}): ${command[0]}`);
+	const child = Bun.spawn(command, {
+		stdin: "ignore",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	const exitCode = await child.exited;
+	if (exitCode !== 0)
+		throw new Error(`command failed (${exitCode}): ${command[0]}`);
 }
 
 function parseArgs(argv: string[]): { planFile: string; dryRun: boolean } {
@@ -104,25 +125,46 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 		const planFile = path.resolve(args.planFile);
 		const planText = await readFile(planFile, "utf8");
 		const plan = parseMoviePlan(planText);
-		const output = path.resolve(path.dirname(planFile), plan.output);
+		const output = path.resolve(plan.output);
 		const stem = path.basename(output, path.extname(output));
 		const sceneDir = path.join(path.dirname(output), `${stem}.scenes`);
 		const config: RuntimeConfig = {
-			hfCacheHubRoot: path.resolve(process.env.HF_CACHE_HUB_ROOT ?? "../hf-cache-hub"),
+			hfCacheHubRoot: path.resolve(
+				process.env.HF_CACHE_HUB_ROOT ?? "../hf-cache-hub",
+			),
 			python: process.env.VIDEO_PYTHON ?? "python3",
 			ffmpeg: process.env.FFMPEG_BIN ?? "ffmpeg",
 		};
 		const scenePaths = plan.scenes.map((scene, index) =>
-			path.join(sceneDir, `${String(index + 1).padStart(3, "0")}-${scene.id}.mp4`),
+			path.join(
+				sceneDir,
+				`${String(index + 1).padStart(3, "0")}-${scene.id}.mp4`,
+			),
 		);
 		const generatorCommands = plan.scenes.map((scene, index) =>
 			buildGeneratorCommand(plan, scene, scenePaths[index] as string, config),
 		);
 		const concatFile = path.join(sceneDir, "concat.txt");
-		const ffmpegCommand = buildFfmpegCommand(concatFile, output, config.ffmpeg);
+		const ffmpegCommand = buildFfmpegCommand(
+			concatFile,
+			output,
+			config.ffmpeg,
+		);
 
 		if (args.dryRun) {
-			console.log(JSON.stringify({ status: "READY", plan: planFile, output, generatorCommands, ffmpegCommand }, null, 2));
+			console.log(
+				JSON.stringify(
+					{
+						status: "READY",
+						plan: planFile,
+						output,
+						generatorCommands,
+						ffmpegCommand,
+					},
+					null,
+					2,
+				),
+			);
 			return 0;
 		}
 
@@ -137,10 +179,26 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 			plan_sha256: createHash("sha256").update(planText).digest("hex"),
 			output,
 			model: plan.model ?? null,
-			scenes: plan.scenes.map((scene, index) => ({ id: scene.id, output: scenePaths[index], prompt: scene.prompt })),
+			scenes: plan.scenes.map((scene, index) => ({
+				id: scene.id,
+				output: scenePaths[index],
+				prompt_sha256: createHash("sha256")
+					.update(scene.prompt)
+					.digest("hex"),
+			})),
 		};
-		await writeFile(`${output}.json`, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
-		console.log(JSON.stringify({ status: "DONE", output, manifest: `${output}.json` }, null, 2));
+		await writeFile(
+			`${output}.json`,
+			`${JSON.stringify(manifest, null, 2)}\n`,
+			"utf8",
+		);
+		console.log(
+			JSON.stringify(
+				{ status: "DONE", output, manifest: `${output}.json` },
+				null,
+				2,
+			),
+		);
 		return 0;
 	} catch (error) {
 		console.error(error instanceof Error ? error.message : String(error));

--- a/tests/generate_movie.test.ts
+++ b/tests/generate_movie.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildConcatFile,
+	buildFfmpegCommand,
+	buildGeneratorCommand,
+	parseMoviePlan,
+	type RuntimeConfig,
+} from "../src/scripts/generate_movie.js";
+
+const CONFIG: RuntimeConfig = {
+	hfCacheHubRoot: "/models/hf-cache-hub",
+	python: "python3",
+	ffmpeg: "ffmpeg",
+};
+
+const PLAN = parseMoviePlan(
+	JSON.stringify({
+		output: "artifacts/generated/movie.mp4",
+		model: "MiniMaxAI/H3",
+		scenes: [
+			{ id: "intro", prompt: "first scene", seed: 42, num_frames: 81 },
+			{ id: "end", prompt: "last scene" },
+		],
+	}),
+);
+
+describe("code-only movie generation", () => {
+	test("parses a non-empty scene plan", () => {
+		expect(PLAN.scenes).toHaveLength(2);
+		expect(PLAN.output).toBe("artifacts/generated/movie.mp4");
+	});
+
+	test("rejects a plan with no scenes", () => {
+		expect(() =>
+			parseMoviePlan(JSON.stringify({ output: "movie.mp4", scenes: [] })),
+		).toThrow();
+	});
+
+	test("builds generator argv without a shell command string", () => {
+		const command = buildGeneratorCommand(
+			PLAN,
+			PLAN.scenes[0]!,
+			"/tmp/001-intro.mp4",
+			CONFIG,
+		);
+		expect(command[0]).toBe("python3");
+		expect(command).toContain("/models/hf-cache-hub/scripts/generate_video.py");
+		expect(command).toContain("first scene");
+		expect(command).toContain("MiniMaxAI/H3");
+		expect(command).toContain("42");
+		expect(command).toContain("81");
+	});
+
+	test("keeps scene order in the ffmpeg concat file", () => {
+		const concat = buildConcatFile(["/tmp/001-intro.mp4", "/tmp/002-end.mp4"]);
+		expect(concat.indexOf("001-intro.mp4")).toBeLessThan(
+			concat.indexOf("002-end.mp4"),
+		);
+	});
+
+	test("builds fail-fast ffmpeg concat argv", () => {
+		expect(buildFfmpegCommand("/tmp/concat.txt", "movie.mp4", "ffmpeg")).toEqual([
+			"ffmpeg",
+			"-y",
+			"-f",
+			"concat",
+			"-safe",
+			"0",
+			"-i",
+			"/tmp/concat.txt",
+			"-c",
+			"copy",
+			"movie.mp4",
+		]);
+	});
+});

--- a/tests/generate_movie.test.ts
+++ b/tests/generate_movie.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+	type RuntimeConfig,
 	buildConcatFile,
 	buildFfmpegCommand,
 	buildGeneratorCommand,
 	parseMoviePlan,
-	type RuntimeConfig,
 } from "../src/scripts/generate_movie.js";
 
 const CONFIG: RuntimeConfig = {
@@ -23,6 +23,8 @@ const PLAN = parseMoviePlan(
 		],
 	}),
 );
+const FIRST_SCENE = PLAN.scenes[0];
+if (!FIRST_SCENE) throw new Error("test plan must contain a scene");
 
 describe("code-only movie generation", () => {
 	test("parses a non-empty scene plan", () => {
@@ -39,7 +41,7 @@ describe("code-only movie generation", () => {
 	test("builds generator argv without a shell command string", () => {
 		const command = buildGeneratorCommand(
 			PLAN,
-			PLAN.scenes[0]!,
+			FIRST_SCENE,
 			"/tmp/001-intro.mp4",
 			CONFIG,
 		);
@@ -59,7 +61,9 @@ describe("code-only movie generation", () => {
 	});
 
 	test("builds fail-fast ffmpeg concat argv", () => {
-		expect(buildFfmpegCommand("/tmp/concat.txt", "movie.mp4", "ffmpeg")).toEqual([
+		expect(
+			buildFfmpegCommand("/tmp/concat.txt", "movie.mp4", "ffmpeg"),
+		).toEqual([
 			"ffmpeg",
 			"-y",
 			"-f",


### PR DESCRIPTION
Implements #16.

- adds one `movie:generate` entrypoint
- reads a JSON scene plan
- calls the revision-pinned Python generator in `hf-cache-hub` with argv, not a shell command
- concatenates generated scenes with ffmpeg
- fails immediately on generator/ffmpeg failure; no fallback path
- supports dry-run without GPU/model/ffmpeg execution
- records plan hash and per-scene prompt hashes without copying prompt text into the final manifest
- leaves `publish:nlm` and `asmr:publish` unchanged

Actual MiniMax H3 rendering remains dependent on `hf-cache-hub#8` official weights/model-card availability.