### PR TITLE
Accept dancer artifacts and harden YouTube publish feedback

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -165,20 +165,23 @@ CREATE TABLE IF NOT EXISTS media_audits (
     UNIQUE(run_id, media_type)
 );
 
--- 11. YouTube Analytics (Quality feedback loop data)
+-- 11. YouTube Analytics (raw API metrics; no unapproved derived score)
 CREATE TABLE IF NOT EXISTS youtube_analytics (
     video_id TEXT NOT NULL,
     channel_id TEXT NOT NULL,
-    age_window TEXT NOT NULL, -- '24h', '7d'
+    age_window TEXT NOT NULL, -- 'published_day', 'first_7d'
     views INTEGER NOT NULL,
+    engaged_views INTEGER,
     watch_time_minutes REAL,
     average_view_duration_seconds REAL,
     average_view_percentage REAL,
     likes INTEGER,
     comments INTEGER,
     shares INTEGER,
-    subscribers_net INTEGER,
-    satisfaction_score REAL,
-    recorded_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
+    subscribers_gained INTEGER,
+    subscribers_lost INTEGER,
+    subscribers_net INTEGER, -- legacy nullable field; ingestion leaves NULL
+    satisfaction_score REAL, -- legacy nullable field; ingestion leaves NULL
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (video_id, age_window)
 );

--- a/src/domain/agents/publish.ts
+++ b/src/domain/agents/publish.ts
@@ -11,6 +11,7 @@ import {
 	tryReuseVerifiedDancerUpload,
 	uploadAndVerifyCaption,
 	verifyScheduledPublish,
+	writeDancerUploadCheckpoint,
 } from "../dancer_publication.js";
 import type { AgentState, AppConfig, PublishResults } from "../types.js";
 import { validateCredentials } from "../validation.js";
@@ -236,6 +237,13 @@ export class PublishAgent extends BaseAgent {
 			"private",
 		);
 		console.log(`[PUBLISH:PRIVATE_VERIFIED] video_id=${videoId}`);
+		writeDancerUploadCheckpoint(this.store.runDir, state, {
+			video_id: videoId,
+			channel_id: snippet.channelId,
+			channel_title: snippet.channelTitle,
+			published_at: snippet.publishedAt ?? "",
+			verified_private_at: privateAttestation.verified_at,
+		});
 
 		if (thumbnailPath) {
 			try {

--- a/src/domain/agents/publish.ts
+++ b/src/domain/agents/publish.ts
@@ -210,7 +210,8 @@ export class PublishAgent extends BaseAgent {
 
 		const dancer = asDancerPublicationState(state);
 		const { thumbnail_path: thumbnailPath } = state;
-		const videoPath = options.publishVideoPath || this.resolvePublishVideoPath(state);
+		const videoPath =
+			options.publishVideoPath || this.resolvePublishVideoPath(state);
 		if (!videoPath) throw new Error("Video path missing");
 		console.log(`[PUBLISH:VIDEO] source=${videoPath}`);
 		const res = await youtube.videos.insert({
@@ -221,10 +222,14 @@ export class PublishAgent extends BaseAgent {
 		const videoId = res.data.id;
 		const snippet = res.data.snippet;
 		const status = res.data.status;
-		if (!videoId) throw new Error("YouTube upload response is missing video id");
-		if (!snippet?.channelId) throw new Error("YouTube upload response is missing channelId");
-		if (!snippet.channelTitle) throw new Error("YouTube upload response is missing channelTitle");
-		if (!status?.privacyStatus) throw new Error("YouTube upload response is missing privacyStatus");
+		if (!videoId)
+			throw new Error("YouTube upload response is missing video id");
+		if (!snippet?.channelId)
+			throw new Error("YouTube upload response is missing channelId");
+		if (!snippet.channelTitle)
+			throw new Error("YouTube upload response is missing channelTitle");
+		if (!status?.privacyStatus)
+			throw new Error("YouTube upload response is missing privacyStatus");
 		if (status.privacyStatus !== "private") {
 			throw new Error(
 				`YouTube upload must stage private; insert returned privacyStatus=${status.privacyStatus}`,
@@ -339,10 +344,16 @@ export class PublishAgent extends BaseAgent {
 			);
 		}
 
-		const client = new google.auth.OAuth2({ clientId, clientSecret, redirectUri });
+		const client = new google.auth.OAuth2({
+			clientId,
+			clientSecret,
+			redirectUri,
+		});
 		const profileName = process.env.YOUTUBE_CHANNEL_PROFILE?.trim();
 		if (!profileName) {
-			throw new Error("YouTube client initialization requires YOUTUBE_CHANNEL_PROFILE");
+			throw new Error(
+				"YouTube client initialization requires YOUTUBE_CHANNEL_PROFILE",
+			);
 		}
 
 		const profile = getYouTubeProfile(profileName);
@@ -372,12 +383,26 @@ export class PublishAgent extends BaseAgent {
 		});
 		let thumbnailVariants: string[] = [];
 		for (let attempt = 0; attempt < 6; attempt++) {
-			const response = await youtube.videos.list({ part: ["snippet"], id: [videoId] });
-			thumbnailVariants = Object.keys(response.data.items?.[0]?.snippet?.thumbnails ?? {});
-			if (["default", "medium", "high"].every((key) => thumbnailVariants.includes(key))) break;
+			const response = await youtube.videos.list({
+				part: ["snippet"],
+				id: [videoId],
+			});
+			thumbnailVariants = Object.keys(
+				response.data.items?.[0]?.snippet?.thumbnails ?? {},
+			);
+			if (
+				["default", "medium", "high"].every((key) =>
+					thumbnailVariants.includes(key),
+				)
+			)
+				break;
 			await new Promise((resolve) => setTimeout(resolve, 3000));
 		}
-		if (!["default", "medium", "high"].every((key) => thumbnailVariants.includes(key))) {
+		if (
+			!["default", "medium", "high"].every((key) =>
+				thumbnailVariants.includes(key),
+			)
+		) {
 			throw new Error(
 				`Thumbnail update could not be verified for ${videoId}; variants=${thumbnailVariants.join(",")}`,
 			);
@@ -411,7 +436,8 @@ export class PublishAgent extends BaseAgent {
 		const { metadata } = state;
 		const videoPath = this.resolvePublishVideoPath(state);
 		let mediaId: string | undefined;
-		if (videoPath && fs.existsSync(videoPath)) mediaId = await client.v1.uploadMedia(videoPath);
+		if (videoPath && fs.existsSync(videoPath))
+			mediaId = await client.v1.uploadMedia(videoPath);
 		const tweetText = this.createTweetText(metadata);
 		const tweetPayload = { text: tweetText } as {
 			text: string;
@@ -424,8 +450,10 @@ export class PublishAgent extends BaseAgent {
 
 	private createTwitterClient() {
 		const appKey = process.env.X_API_KEY || process.env.TWITTER_API_KEY;
-		const appSecret = process.env.X_API_SECRET || process.env.TWITTER_API_SECRET;
-		const accessToken = process.env.X_ACCESS_TOKEN || process.env.TWITTER_ACCESS_TOKEN;
+		const appSecret =
+			process.env.X_API_SECRET || process.env.TWITTER_API_SECRET;
+		const accessToken =
+			process.env.X_ACCESS_TOKEN || process.env.TWITTER_ACCESS_TOKEN;
 		const accessSecret =
 			process.env.X_ACCESS_SECRET || process.env.TWITTER_ACCESS_TOKEN_SECRET;
 		if (!appKey || !appSecret || !accessToken || !accessSecret) {

--- a/src/domain/agents/publish.ts
+++ b/src/domain/agents/publish.ts
@@ -5,6 +5,13 @@ import { TwitterApi } from "twitter-api-v2";
 import { type AssetStore, BaseAgent, RunStage } from "../../io/core.js";
 import { sendAlert } from "../../io/utils/discord.js";
 import { ensureYouTubeVideoVisibility } from "../../io/utils/youtube_visibility.js";
+import {
+	asDancerPublicationState,
+	buildYouTubeStatus,
+	tryReuseVerifiedDancerUpload,
+	uploadAndVerifyCaption,
+	verifyScheduledPublish,
+} from "../dancer_publication.js";
 import type { AgentState, AppConfig, PublishResults } from "../types.js";
 import { validateCredentials } from "../validation.js";
 import {
@@ -12,6 +19,7 @@ import {
 	getYouTubeProfile,
 	hydrateOAuthCredentials,
 } from "../youtube_profiles.js";
+
 export class PublishAgent extends BaseAgent {
 	constructor(store: AssetStore) {
 		super(store, RunStage.PUBLISH);
@@ -37,10 +45,10 @@ export class PublishAgent extends BaseAgent {
 					"YouTube publish requires an explicit channel profile (set YOUTUBE_CHANNEL_PROFILE to byosan, yawa, or humanity)",
 				);
 			}
-
 			getYouTubeProfile(profileName);
 		}
 	}
+
 	async run(state: AgentState): Promise<PublishResults> {
 		const publishVideoPath = this.resolvePublishVideoPath(state);
 		if (publishVideoPath) {
@@ -65,7 +73,7 @@ export class PublishAgent extends BaseAgent {
 					? `https://www.youtube.com/watch?v=${videoId}`
 					: "N/A";
 				await sendAlert(
-					`✅ **Successfully Published** video to ${channelTitle}!`,
+					`✅ **Successfully uploaded** video to ${channelTitle}!`,
 					"publish",
 					{
 						title: state.metadata?.title || "N/A",
@@ -99,10 +107,21 @@ export class PublishAgent extends BaseAgent {
 				"receipt.json",
 			);
 			fs.ensureDirSync(path.dirname(receiptPath));
-			fs.writeJsonSync(receiptPath, results, { spaces: 2 });
+			const dancer = asDancerPublicationState(state);
+			fs.writeJsonSync(
+				receiptPath,
+				{
+					...results,
+					...(dancer.source_artifact_sha256
+						? { source_artifact_sha256: dancer.source_artifact_sha256 }
+						: {}),
+				},
+				{ spaces: 2 },
+			);
 		}
 		return results;
 	}
+
 	private assertNoFallbackPublish(
 		state: AgentState,
 		publishVideoPath?: string,
@@ -141,6 +160,7 @@ export class PublishAgent extends BaseAgent {
 			);
 		}
 	}
+
 	private async uploadToYouTube(
 		state: AgentState,
 		cfg: AppConfig,
@@ -174,14 +194,22 @@ export class PublishAgent extends BaseAgent {
 		);
 
 		const auth = await this.createYouTubeClient();
-		const youtube = google.youtube({
-			version: "v3",
-			auth,
-		});
+		const youtube = google.youtube({ version: "v3", auth });
 		await this.verifyYouTubeChannel(auth);
+		const reusable = await tryReuseVerifiedDancerUpload(
+			youtube,
+			state,
+			this.store.runDir,
+			profile,
+		);
+		if (reusable) {
+			console.log(`[PUBLISH:IDEMPOTENT_REUSE] video_id=${reusable.video_id}`);
+			return reusable;
+		}
+
+		const dancer = asDancerPublicationState(state);
 		const { thumbnail_path: thumbnailPath } = state;
-		const videoPath =
-			options.publishVideoPath || this.resolvePublishVideoPath(state);
+		const videoPath = options.publishVideoPath || this.resolvePublishVideoPath(state);
 		if (!videoPath) throw new Error("Video path missing");
 		console.log(`[PUBLISH:VIDEO] source=${videoPath}`);
 		const res = await youtube.videos.insert({
@@ -192,18 +220,10 @@ export class PublishAgent extends BaseAgent {
 		const videoId = res.data.id;
 		const snippet = res.data.snippet;
 		const status = res.data.status;
-		if (!videoId) {
-			throw new Error("YouTube upload response is missing video id");
-		}
-		if (!snippet?.channelId) {
-			throw new Error("YouTube upload response is missing channelId");
-		}
-		if (!snippet.channelTitle) {
-			throw new Error("YouTube upload response is missing channelTitle");
-		}
-		if (!status?.privacyStatus) {
-			throw new Error("YouTube upload response is missing privacyStatus");
-		}
+		if (!videoId) throw new Error("YouTube upload response is missing video id");
+		if (!snippet?.channelId) throw new Error("YouTube upload response is missing channelId");
+		if (!snippet.channelTitle) throw new Error("YouTube upload response is missing channelTitle");
+		if (!status?.privacyStatus) throw new Error("YouTube upload response is missing privacyStatus");
 		if (status.privacyStatus !== "private") {
 			throw new Error(
 				`YouTube upload must stage private; insert returned privacyStatus=${status.privacyStatus}`,
@@ -221,25 +241,43 @@ export class PublishAgent extends BaseAgent {
 			try {
 				await this.setYouTubeThumbnail(youtube, videoId, thumbnailPath);
 			} catch (error) {
+				if (dancer.source_manifest_path) throw error;
 				console.warn(
 					`YouTube thumbnail upload skipped for ${videoId}: ${(error as Error).message}`,
 				);
 			}
 		}
-		const visibilityAttestation =
-			ytCfg.default_visibility === "private"
-				? privateAttestation
-				: await ensureYouTubeVideoVisibility(
-						auth,
-						videoId,
-						ytCfg.default_visibility,
-					);
+		if (dancer.caption_path) {
+			await uploadAndVerifyCaption(
+				youtube,
+				videoId,
+				dancer.caption_path,
+				this.store.runDir,
+			);
+		}
+
+		let visibilityAttestation = privateAttestation;
+		if (dancer.publish_at) {
+			await verifyScheduledPublish(
+				youtube,
+				videoId,
+				dancer.publish_at,
+				this.store.runDir,
+			);
+		} else if (ytCfg.default_visibility !== "private") {
+			visibilityAttestation = await ensureYouTubeVideoVisibility(
+				auth,
+				videoId,
+				ytCfg.default_visibility,
+			);
+		}
 		fs.writeJsonSync(
 			path.join(this.store.runDir, "publish", "visibility_attestation.json"),
 			{
 				...visibilityAttestation,
 				staged_private: true,
 				private_verified_at: privateAttestation.verified_at,
+				...(dancer.publish_at ? { scheduled_for: dancer.publish_at } : {}),
 			},
 			{ spaces: 2 },
 		);
@@ -252,6 +290,7 @@ export class PublishAgent extends BaseAgent {
 			published_at: snippet.publishedAt ?? "",
 		};
 	}
+
 	private createYouTubeSnippet(
 		state: AgentState,
 		ytCfg: NonNullable<AppConfig["steps"]["youtube"]>,
@@ -267,12 +306,10 @@ export class PublishAgent extends BaseAgent {
 				tags: [...(ytCfg.default_tags || []), ...(metadata?.tags || [])],
 				categoryId: (ytCfg.category_id || 24).toString(),
 			},
-			status: {
-				privacyStatus: "private",
-				selfDeclaredMadeForKids: false,
-			},
+			status: buildYouTubeStatus(state),
 		};
 	}
+
 	private async verifyYouTubeChannel(
 		auth: InstanceType<typeof google.auth.OAuth2>,
 	) {
@@ -280,6 +317,7 @@ export class PublishAgent extends BaseAgent {
 		const profile = getYouTubeProfile(profileName);
 		await assertYouTubeChannelMatchesProfile(auth, profile);
 	}
+
 	private async createYouTubeClient() {
 		const clientId = process.env.YOUTUBE_CLIENT_ID;
 		const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
@@ -293,38 +331,28 @@ export class PublishAgent extends BaseAgent {
 			);
 		}
 
-		const client = new google.auth.OAuth2({
-			clientId,
-			clientSecret,
-			redirectUri,
-		});
-
+		const client = new google.auth.OAuth2({ clientId, clientSecret, redirectUri });
 		const profileName = process.env.YOUTUBE_CHANNEL_PROFILE?.trim();
 		if (!profileName) {
-			throw new Error(
-				"YouTube client initialization requires YOUTUBE_CHANNEL_PROFILE",
-			);
+			throw new Error("YouTube client initialization requires YOUTUBE_CHANNEL_PROFILE");
 		}
 
-		if (profileName === "humanity") {
-			const profile = getYouTubeProfile(profileName);
-			await hydrateOAuthCredentials(client, profile);
-		} else {
-			const refreshToken = process.env.YOUTUBE_REFRESH_TOKEN;
-			if (refreshToken) {
-				client.setCredentials({ refresh_token: refreshToken });
-			}
-		}
-
+		const profile = getYouTubeProfile(profileName);
+		await hydrateOAuthCredentials(client, profile);
 		return client;
 	}
+
 	private async setYouTubeThumbnail(
 		youtube: ReturnType<typeof google.youtube>,
 		videoId: string,
 		thumbnailPath: string,
 	) {
+		const sizeBytes = fs.statSync(thumbnailPath).size;
+		if (sizeBytes > 2 * 1024 * 1024) {
+			throw new Error(`YouTube thumbnail exceeds 2 MB: ${sizeBytes} bytes`);
+		}
 		await youtube.thumbnails.set({
-			videoId: videoId,
+			videoId,
 			media: {
 				mimeType:
 					path.extname(thumbnailPath).toLowerCase() === ".jpg" ||
@@ -336,27 +364,12 @@ export class PublishAgent extends BaseAgent {
 		});
 		let thumbnailVariants: string[] = [];
 		for (let attempt = 0; attempt < 6; attempt++) {
-			const response = await youtube.videos.list({
-				part: ["snippet"],
-				id: [videoId],
-			});
-			thumbnailVariants = Object.keys(
-				response.data.items?.[0]?.snippet?.thumbnails ?? {},
-			);
-			if (
-				["default", "medium", "high"].every((key) =>
-					thumbnailVariants.includes(key),
-				)
-			) {
-				break;
-			}
+			const response = await youtube.videos.list({ part: ["snippet"], id: [videoId] });
+			thumbnailVariants = Object.keys(response.data.items?.[0]?.snippet?.thumbnails ?? {});
+			if (["default", "medium", "high"].every((key) => thumbnailVariants.includes(key))) break;
 			await new Promise((resolve) => setTimeout(resolve, 3000));
 		}
-		if (
-			!["default", "medium", "high"].every((key) =>
-				thumbnailVariants.includes(key),
-			)
-		) {
+		if (!["default", "medium", "high"].every((key) => thumbnailVariants.includes(key))) {
 			throw new Error(
 				`Thumbnail update could not be verified for ${videoId}; variants=${thumbnailVariants.join(",")}`,
 			);
@@ -371,7 +384,7 @@ export class PublishAgent extends BaseAgent {
 					path.extname(thumbnailPath).toLowerCase() === ".jpeg"
 						? "image/jpeg"
 						: "image/png",
-				size_bytes: fs.statSync(thumbnailPath).size,
+				size_bytes: sizeBytes,
 				api_update_status: "succeeded",
 				thumbnail_variants: thumbnailVariants,
 				verified_at: new Date().toISOString(),
@@ -379,19 +392,18 @@ export class PublishAgent extends BaseAgent {
 			{ spaces: 2 },
 		);
 	}
+
 	private async postToTwitter(
 		state: AgentState,
 		cfg: AppConfig,
 	): Promise<PublishResults["twitter"]> {
 		const twCfg = cfg.steps.twitter;
 		if (!twCfg) throw new Error("Twitter config missing");
-
 		const client = this.createTwitterClient();
 		const { metadata } = state;
 		const videoPath = this.resolvePublishVideoPath(state);
 		let mediaId: string | undefined;
-		if (videoPath && fs.existsSync(videoPath))
-			mediaId = await client.v1.uploadMedia(videoPath);
+		if (videoPath && fs.existsSync(videoPath)) mediaId = await client.v1.uploadMedia(videoPath);
 		const tweetText = this.createTweetText(metadata);
 		const tweetPayload = { text: tweetText } as {
 			text: string;
@@ -401,28 +413,21 @@ export class PublishAgent extends BaseAgent {
 		const res = await client.v2.tweet(tweetPayload as { text: string });
 		return { status: "posted", tweet_id: res.data.id || "" };
 	}
+
 	private createTwitterClient() {
 		const appKey = process.env.X_API_KEY || process.env.TWITTER_API_KEY;
-		const appSecret =
-			process.env.X_API_SECRET || process.env.TWITTER_API_SECRET;
-		const accessToken =
-			process.env.X_ACCESS_TOKEN || process.env.TWITTER_ACCESS_TOKEN;
+		const appSecret = process.env.X_API_SECRET || process.env.TWITTER_API_SECRET;
+		const accessToken = process.env.X_ACCESS_TOKEN || process.env.TWITTER_ACCESS_TOKEN;
 		const accessSecret =
 			process.env.X_ACCESS_SECRET || process.env.TWITTER_ACCESS_TOKEN_SECRET;
-
 		if (!appKey || !appSecret || !accessToken || !accessSecret) {
 			throw new Error(
 				"Twitter authentication failed: unable to initialize Twitter client",
 			);
 		}
-
-		return new TwitterApi({
-			appKey,
-			appSecret,
-			accessToken,
-			accessSecret,
-		});
+		return new TwitterApi({ appKey, appSecret, accessToken, accessSecret });
 	}
+
 	private createTweetText(metadata?: AgentState["metadata"]) {
 		const tags = (metadata?.tags || []).map((t) => `#${t}`).join(" ");
 		return `${metadata?.title || ""}\n\n${tags}`.substring(0, 280);
@@ -448,13 +453,10 @@ export class PublishAgent extends BaseAgent {
 				? candidate
 				: path.join(this.store.runDir, candidate);
 			if (fs.existsSync(resolved)) {
-				if (resolved !== state.video_path) {
-					state.publish_video_path = resolved;
-				}
+				if (resolved !== state.video_path) state.publish_video_path = resolved;
 				return resolved;
 			}
 		}
-
 		return state.video_path || "";
 	}
 }

--- a/src/domain/dancer_publication.ts
+++ b/src/domain/dancer_publication.ts
@@ -1,0 +1,131 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { google } from "googleapis";
+import type { AgentState, PublishResults } from "./types.js";
+import type { YouTubeProfile } from "./youtube_profiles.js";
+
+export type DancerPublicationState = AgentState & {
+	caption_path?: string;
+	source_manifest_path?: string;
+	source_artifact_sha256?: string;
+	contains_synthetic_media?: boolean;
+	publish_at?: string;
+};
+
+type StoredReceipt = PublishResults & { source_artifact_sha256?: string };
+
+export function asDancerPublicationState(state: AgentState): DancerPublicationState {
+	return state as DancerPublicationState;
+}
+
+export function buildYouTubeStatus(state: AgentState) {
+	const dancer = asDancerPublicationState(state);
+	const status: {
+		privacyStatus: "private";
+		selfDeclaredMadeForKids: false;
+		containsSyntheticMedia?: boolean;
+		publishAt?: string;
+	} = {
+		privacyStatus: "private",
+		selfDeclaredMadeForKids: false,
+	};
+	if (typeof dancer.contains_synthetic_media === "boolean") {
+		status.containsSyntheticMedia = dancer.contains_synthetic_media;
+	}
+	if (dancer.publish_at) {
+		const timestamp = Date.parse(dancer.publish_at);
+		if (!Number.isFinite(timestamp)) throw new Error(`Invalid publish_at timestamp: ${dancer.publish_at}`);
+		if (timestamp <= Date.now()) throw new Error(`publish_at must be in the future: ${dancer.publish_at}`);
+		status.publishAt = new Date(timestamp).toISOString();
+	}
+	return status;
+}
+
+export async function tryReuseVerifiedDancerUpload(
+	youtube: ReturnType<typeof google.youtube>,
+	state: AgentState,
+	runDir: string,
+	profile: YouTubeProfile,
+): Promise<PublishResults["youtube"] | null> {
+	const dancer = asDancerPublicationState(state);
+	if (!dancer.source_manifest_path || !dancer.source_artifact_sha256) return null;
+	const receiptPath = path.join(runDir, "publish", "receipt.json");
+	if (!fs.existsSync(receiptPath)) return null;
+	const receipt = fs.readJsonSync(receiptPath) as StoredReceipt;
+	if (receipt.source_artifact_sha256 !== dancer.source_artifact_sha256) return null;
+	const videoId = receipt.youtube?.video_id;
+	if (!videoId) return null;
+	const response = await youtube.videos.list({ part: ["snippet", "status"], id: [videoId] });
+	const item = response.data.items?.[0];
+	if (!item) return null;
+	if (item.snippet?.channelId !== profile.expectedChannelId) {
+		throw new Error(
+			`Stored publish receipt points to the wrong channel: expected ${profile.expectedChannelId}, got ${item.snippet?.channelId || "missing"}`,
+		);
+	}
+	return {
+		status: "uploaded",
+		video_id: videoId,
+		channel_id: item.snippet.channelId,
+		channel_title: item.snippet.channelTitle ?? profile.expectedChannelTitle,
+		privacy_status: item.status?.privacyStatus ?? "unknown",
+		published_at: item.snippet.publishedAt ?? receipt.youtube?.published_at ?? "",
+	};
+}
+
+export async function uploadAndVerifyCaption(
+	youtube: ReturnType<typeof google.youtube>,
+	videoId: string,
+	captionPath: string,
+	runDir: string,
+): Promise<void> {
+	if (!fs.existsSync(captionPath)) throw new Error(`Caption file does not exist: ${captionPath}`);
+	const extension = path.extname(captionPath).toLowerCase();
+	if (extension !== ".vtt" && extension !== ".srt") throw new Error(`Unsupported caption format: ${extension}`);
+	const response = await youtube.captions.insert({
+		part: ["snippet"],
+		requestBody: { snippet: { videoId, language: "ja", name: "Japanese" } },
+		media: { mimeType: "application/octet-stream", body: fs.createReadStream(captionPath) },
+	});
+	const captionId = response.data.id;
+	if (!captionId) throw new Error("YouTube caption upload response is missing id");
+	let finalStatus = response.data.snippet?.status ?? "unknown";
+	for (let attempt = 0; attempt < 6 && finalStatus !== "serving"; attempt++) {
+		if (finalStatus === "failed") break;
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+		const lookup = await youtube.captions.list({ part: ["snippet"], videoId, id: [captionId] });
+		finalStatus = lookup.data.items?.[0]?.snippet?.status ?? "unknown";
+	}
+	if (finalStatus !== "serving") throw new Error(`Caption could not be verified as serving: status=${finalStatus}`);
+	fs.ensureDirSync(path.join(runDir, "publish"));
+	fs.writeJsonSync(
+		path.join(runDir, "publish", "caption_attestation.json"),
+		{ video_id: videoId, caption_id: captionId, source_path: captionPath, status: finalStatus, verified_at: new Date().toISOString() },
+		{ spaces: 2 },
+	);
+}
+
+export async function verifyScheduledPublish(
+	youtube: ReturnType<typeof google.youtube>,
+	videoId: string,
+	publishAt: string,
+	runDir: string,
+): Promise<void> {
+	const response = await youtube.videos.list({ part: ["status"], id: [videoId] });
+	const status = response.data.items?.[0]?.status;
+	if (!status) throw new Error(`Unable to verify scheduled video status: ${videoId}`);
+	if (status.privacyStatus !== "private") {
+		throw new Error(`Scheduled video must remain private before publishAt: got ${status.privacyStatus}`);
+	}
+	const expected = Date.parse(publishAt);
+	const actual = Date.parse(status.publishAt ?? "");
+	if (!Number.isFinite(actual) || Math.abs(actual - expected) > 1000) {
+		throw new Error(`Scheduled publishAt mismatch: expected ${new Date(expected).toISOString()}, got ${status.publishAt || "missing"}`);
+	}
+	fs.ensureDirSync(path.join(runDir, "publish"));
+	fs.writeJsonSync(
+		path.join(runDir, "publish", "schedule_attestation.json"),
+		{ video_id: videoId, privacy_status: status.privacyStatus, publish_at: status.publishAt, verified_at: new Date().toISOString() },
+		{ spaces: 2 },
+	);
+}

--- a/src/domain/dancer_publication.ts
+++ b/src/domain/dancer_publication.ts
@@ -13,6 +13,14 @@ export type DancerPublicationState = AgentState & {
 };
 
 type StoredReceipt = PublishResults & { source_artifact_sha256?: string };
+type UploadCheckpoint = {
+	source_artifact_sha256: string;
+	video_id: string;
+	channel_id: string;
+	channel_title: string;
+	published_at: string;
+	verified_private_at: string;
+};
 
 export function asDancerPublicationState(state: AgentState): DancerPublicationState {
 	return state as DancerPublicationState;
@@ -41,6 +49,64 @@ export function buildYouTubeStatus(state: AgentState) {
 	return status;
 }
 
+export function writeDancerUploadCheckpoint(
+	runDir: string,
+	state: AgentState,
+	input: Omit<UploadCheckpoint, "source_artifact_sha256">,
+): void {
+	const dancer = asDancerPublicationState(state);
+	if (!dancer.source_manifest_path || !dancer.source_artifact_sha256) return;
+	const publishDir = path.join(runDir, "publish");
+	fs.ensureDirSync(publishDir);
+	fs.writeJsonSync(
+		path.join(publishDir, "upload_attestation.json"),
+		{ source_artifact_sha256: dancer.source_artifact_sha256, ...input },
+		{ spaces: 2 },
+	);
+}
+
+function storedUploadForHash(
+	runDir: string,
+	sourceArtifactSha256: string,
+): {
+	videoId: string;
+	channelId?: string;
+	channelTitle?: string;
+	publishedAt?: string;
+} | null {
+	const receiptPath = path.join(runDir, "publish", "receipt.json");
+	if (fs.existsSync(receiptPath)) {
+		const receipt = fs.readJsonSync(receiptPath) as StoredReceipt;
+		if (
+			receipt.source_artifact_sha256 === sourceArtifactSha256 &&
+			receipt.youtube?.video_id
+		) {
+			return {
+				videoId: receipt.youtube.video_id,
+				channelId: receipt.youtube.channel_id,
+				channelTitle: receipt.youtube.channel_title,
+				publishedAt: receipt.youtube.published_at,
+			};
+		}
+	}
+	const checkpointPath = path.join(runDir, "publish", "upload_attestation.json");
+	if (fs.existsSync(checkpointPath)) {
+		const checkpoint = fs.readJsonSync(checkpointPath) as UploadCheckpoint;
+		if (
+			checkpoint.source_artifact_sha256 === sourceArtifactSha256 &&
+			checkpoint.video_id
+		) {
+			return {
+				videoId: checkpoint.video_id,
+				channelId: checkpoint.channel_id,
+				channelTitle: checkpoint.channel_title,
+				publishedAt: checkpoint.published_at,
+			};
+		}
+	}
+	return null;
+}
+
 export async function tryReuseVerifiedDancerUpload(
 	youtube: ReturnType<typeof google.youtube>,
 	state: AgentState,
@@ -49,27 +115,23 @@ export async function tryReuseVerifiedDancerUpload(
 ): Promise<PublishResults["youtube"] | null> {
 	const dancer = asDancerPublicationState(state);
 	if (!dancer.source_manifest_path || !dancer.source_artifact_sha256) return null;
-	const receiptPath = path.join(runDir, "publish", "receipt.json");
-	if (!fs.existsSync(receiptPath)) return null;
-	const receipt = fs.readJsonSync(receiptPath) as StoredReceipt;
-	if (receipt.source_artifact_sha256 !== dancer.source_artifact_sha256) return null;
-	const videoId = receipt.youtube?.video_id;
-	if (!videoId) return null;
-	const response = await youtube.videos.list({ part: ["snippet", "status"], id: [videoId] });
+	const stored = storedUploadForHash(runDir, dancer.source_artifact_sha256);
+	if (!stored) return null;
+	const response = await youtube.videos.list({ part: ["snippet", "status"], id: [stored.videoId] });
 	const item = response.data.items?.[0];
 	if (!item) return null;
 	if (item.snippet?.channelId !== profile.expectedChannelId) {
 		throw new Error(
-			`Stored publish receipt points to the wrong channel: expected ${profile.expectedChannelId}, got ${item.snippet?.channelId || "missing"}`,
+			`Stored dancer upload points to the wrong channel: expected ${profile.expectedChannelId}, got ${item.snippet?.channelId || "missing"}`,
 		);
 	}
 	return {
 		status: "uploaded",
-		video_id: videoId,
+		video_id: stored.videoId,
 		channel_id: item.snippet.channelId,
-		channel_title: item.snippet.channelTitle ?? profile.expectedChannelTitle,
+		channel_title: item.snippet.channelTitle ?? stored.channelTitle ?? profile.expectedChannelTitle,
 		privacy_status: item.status?.privacyStatus ?? "unknown",
-		published_at: item.snippet.publishedAt ?? receipt.youtube?.published_at ?? "",
+		published_at: item.snippet.publishedAt ?? stored.publishedAt ?? "",
 	};
 }
 

--- a/src/domain/dancer_publication.ts
+++ b/src/domain/dancer_publication.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import fs from "fs-extra";
-import { google } from "googleapis";
+import type { google } from "googleapis";
 import type { AgentState, PublishResults } from "./types.js";
 import type { YouTubeProfile } from "./youtube_profiles.js";
 
@@ -22,7 +22,9 @@ type UploadCheckpoint = {
 	verified_private_at: string;
 };
 
-export function asDancerPublicationState(state: AgentState): DancerPublicationState {
+export function asDancerPublicationState(
+	state: AgentState,
+): DancerPublicationState {
 	return state as DancerPublicationState;
 }
 
@@ -42,8 +44,10 @@ export function buildYouTubeStatus(state: AgentState) {
 	}
 	if (dancer.publish_at) {
 		const timestamp = Date.parse(dancer.publish_at);
-		if (!Number.isFinite(timestamp)) throw new Error(`Invalid publish_at timestamp: ${dancer.publish_at}`);
-		if (timestamp <= Date.now()) throw new Error(`publish_at must be in the future: ${dancer.publish_at}`);
+		if (!Number.isFinite(timestamp))
+			throw new Error(`Invalid publish_at timestamp: ${dancer.publish_at}`);
+		if (timestamp <= Date.now())
+			throw new Error(`publish_at must be in the future: ${dancer.publish_at}`);
 		status.publishAt = new Date(timestamp).toISOString();
 	}
 	return status;
@@ -89,7 +93,11 @@ function storedUploadForHash(
 			};
 		}
 	}
-	const checkpointPath = path.join(runDir, "publish", "upload_attestation.json");
+	const checkpointPath = path.join(
+		runDir,
+		"publish",
+		"upload_attestation.json",
+	);
 	if (fs.existsSync(checkpointPath)) {
 		const checkpoint = fs.readJsonSync(checkpointPath) as UploadCheckpoint;
 		if (
@@ -114,10 +122,14 @@ export async function tryReuseVerifiedDancerUpload(
 	profile: YouTubeProfile,
 ): Promise<PublishResults["youtube"] | null> {
 	const dancer = asDancerPublicationState(state);
-	if (!dancer.source_manifest_path || !dancer.source_artifact_sha256) return null;
+	if (!dancer.source_manifest_path || !dancer.source_artifact_sha256)
+		return null;
 	const stored = storedUploadForHash(runDir, dancer.source_artifact_sha256);
 	if (!stored) return null;
-	const response = await youtube.videos.list({ part: ["snippet", "status"], id: [stored.videoId] });
+	const response = await youtube.videos.list({
+		part: ["snippet", "status"],
+		id: [stored.videoId],
+	});
 	const item = response.data.items?.[0];
 	if (!item) return null;
 	if (item.snippet?.channelId !== profile.expectedChannelId) {
@@ -129,7 +141,10 @@ export async function tryReuseVerifiedDancerUpload(
 		status: "uploaded",
 		video_id: stored.videoId,
 		channel_id: item.snippet.channelId,
-		channel_title: item.snippet.channelTitle ?? stored.channelTitle ?? profile.expectedChannelTitle,
+		channel_title:
+			item.snippet.channelTitle ??
+			stored.channelTitle ??
+			profile.expectedChannelTitle,
 		privacy_status: item.status?.privacyStatus ?? "unknown",
 		published_at: item.snippet.publishedAt ?? stored.publishedAt ?? "",
 	};
@@ -141,28 +156,47 @@ export async function uploadAndVerifyCaption(
 	captionPath: string,
 	runDir: string,
 ): Promise<void> {
-	if (!fs.existsSync(captionPath)) throw new Error(`Caption file does not exist: ${captionPath}`);
+	if (!fs.existsSync(captionPath))
+		throw new Error(`Caption file does not exist: ${captionPath}`);
 	const extension = path.extname(captionPath).toLowerCase();
-	if (extension !== ".vtt" && extension !== ".srt") throw new Error(`Unsupported caption format: ${extension}`);
+	if (extension !== ".vtt" && extension !== ".srt")
+		throw new Error(`Unsupported caption format: ${extension}`);
 	const response = await youtube.captions.insert({
 		part: ["snippet"],
 		requestBody: { snippet: { videoId, language: "ja", name: "Japanese" } },
-		media: { mimeType: "application/octet-stream", body: fs.createReadStream(captionPath) },
+		media: {
+			mimeType: "application/octet-stream",
+			body: fs.createReadStream(captionPath),
+		},
 	});
 	const captionId = response.data.id;
-	if (!captionId) throw new Error("YouTube caption upload response is missing id");
+	if (!captionId)
+		throw new Error("YouTube caption upload response is missing id");
 	let finalStatus = response.data.snippet?.status ?? "unknown";
 	for (let attempt = 0; attempt < 6 && finalStatus !== "serving"; attempt++) {
 		if (finalStatus === "failed") break;
 		await new Promise((resolve) => setTimeout(resolve, 3000));
-		const lookup = await youtube.captions.list({ part: ["snippet"], videoId, id: [captionId] });
+		const lookup = await youtube.captions.list({
+			part: ["snippet"],
+			videoId,
+			id: [captionId],
+		});
 		finalStatus = lookup.data.items?.[0]?.snippet?.status ?? "unknown";
 	}
-	if (finalStatus !== "serving") throw new Error(`Caption could not be verified as serving: status=${finalStatus}`);
+	if (finalStatus !== "serving")
+		throw new Error(
+			`Caption could not be verified as serving: status=${finalStatus}`,
+		);
 	fs.ensureDirSync(path.join(runDir, "publish"));
 	fs.writeJsonSync(
 		path.join(runDir, "publish", "caption_attestation.json"),
-		{ video_id: videoId, caption_id: captionId, source_path: captionPath, status: finalStatus, verified_at: new Date().toISOString() },
+		{
+			video_id: videoId,
+			caption_id: captionId,
+			source_path: captionPath,
+			status: finalStatus,
+			verified_at: new Date().toISOString(),
+		},
 		{ spaces: 2 },
 	);
 }
@@ -173,21 +207,34 @@ export async function verifyScheduledPublish(
 	publishAt: string,
 	runDir: string,
 ): Promise<void> {
-	const response = await youtube.videos.list({ part: ["status"], id: [videoId] });
+	const response = await youtube.videos.list({
+		part: ["status"],
+		id: [videoId],
+	});
 	const status = response.data.items?.[0]?.status;
-	if (!status) throw new Error(`Unable to verify scheduled video status: ${videoId}`);
+	if (!status)
+		throw new Error(`Unable to verify scheduled video status: ${videoId}`);
 	if (status.privacyStatus !== "private") {
-		throw new Error(`Scheduled video must remain private before publishAt: got ${status.privacyStatus}`);
+		throw new Error(
+			`Scheduled video must remain private before publishAt: got ${status.privacyStatus}`,
+		);
 	}
 	const expected = Date.parse(publishAt);
 	const actual = Date.parse(status.publishAt ?? "");
 	if (!Number.isFinite(actual) || Math.abs(actual - expected) > 1000) {
-		throw new Error(`Scheduled publishAt mismatch: expected ${new Date(expected).toISOString()}, got ${status.publishAt || "missing"}`);
+		throw new Error(
+			`Scheduled publishAt mismatch: expected ${new Date(expected).toISOString()}, got ${status.publishAt || "missing"}`,
+		);
 	}
 	fs.ensureDirSync(path.join(runDir, "publish"));
 	fs.writeJsonSync(
 		path.join(runDir, "publish", "schedule_attestation.json"),
-		{ video_id: videoId, privacy_status: status.privacyStatus, publish_at: status.publishAt, verified_at: new Date().toISOString() },
+		{
+			video_id: videoId,
+			privacy_status: status.privacyStatus,
+			publish_at: status.publishAt,
+			verified_at: new Date().toISOString(),
+		},
 		{ spaces: 2 },
 	);
 }

--- a/src/scripts/import_dancer_artifact.ts
+++ b/src/scripts/import_dancer_artifact.ts
@@ -1,0 +1,103 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import fs from "fs-extra";
+import { AssetStore, type AgentState } from "../io/core.js";
+import { getYouTubeProfile } from "../domain/youtube_profiles.js";
+
+type DancerManifest = {
+	schema_version: number;
+	run_id: string;
+	selected?: { video_path?: string; video_sha256?: string };
+	thumbnail?: { path?: string; size_bytes?: number; mime_type?: string; source_video_sha256?: string };
+	metadata?: { title?: string; description?: string; tags?: string[]; thumbnail_title?: string; path?: string };
+	caption_path?: string | null;
+	publish_at?: string | null;
+	compliance?: { passed?: boolean; contains_synthetic_media?: boolean };
+};
+
+function sha256(filePath: string): string {
+	const hash = crypto.createHash("sha256");
+	hash.update(fs.readFileSync(filePath));
+	return hash.digest("hex");
+}
+
+function requireFile(rawPath: string | undefined, label: string): string {
+	if (!rawPath) throw new Error(`Dancer manifest is missing ${label}`);
+	const resolved = path.resolve(rawPath);
+	if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) throw new Error(`${label} does not exist: ${resolved}`);
+	return resolved;
+}
+
+function main() {
+	const manifestArg = process.argv[2];
+	const profileArg = process.argv[3];
+	if (!manifestArg || !profileArg) {
+		throw new Error("Usage: bun src/scripts/import_dancer_artifact.ts <manifest.json> <byosan|yawa|humanity>");
+	}
+	process.env.YOUTUBE_CHANNEL_PROFILE = profileArg;
+	const profile = getYouTubeProfile(profileArg);
+	const manifestPath = requireFile(manifestArg, "manifest path");
+	const manifest = fs.readJsonSync(manifestPath) as DancerManifest;
+	if (manifest.schema_version !== 1) throw new Error(`Unsupported dancer manifest schema: ${manifest.schema_version}`);
+	if (!manifest.run_id || !/^dancer-[a-f0-9]{20}$/.test(manifest.run_id)) throw new Error(`Invalid dancer run id: ${manifest.run_id || "missing"}`);
+	if (manifest.compliance?.passed !== true) throw new Error("Dancer manifest did not pass the rights/provenance compliance gate");
+	const videoPath = requireFile(manifest.selected?.video_path, "selected video");
+	const expectedVideoHash = manifest.selected?.video_sha256;
+	if (!expectedVideoHash || sha256(videoPath) !== expectedVideoHash) throw new Error("Dancer selected video SHA-256 does not match manifest");
+	if (manifest.thumbnail?.source_video_sha256 !== expectedVideoHash) throw new Error("Dancer thumbnail provenance does not match selected video hash");
+	const thumbnailPath = requireFile(manifest.thumbnail?.path, "thumbnail");
+	const thumbnailSize = fs.statSync(thumbnailPath).size;
+	if (thumbnailSize > 2 * 1024 * 1024) throw new Error(`Dancer thumbnail exceeds YouTube 2 MB limit: ${thumbnailSize} bytes`);
+	const thumbnailExtension = path.extname(thumbnailPath).toLowerCase();
+	if (![".jpg", ".jpeg", ".png"].includes(thumbnailExtension)) throw new Error(`Unsupported thumbnail format: ${thumbnailExtension}`);
+	const metadata = manifest.metadata;
+	if (!metadata?.title || !metadata.description || !metadata.thumbnail_title || !Array.isArray(metadata.tags)) {
+		throw new Error("Dancer manifest metadata is incomplete");
+	}
+	const captionPath = manifest.caption_path ? requireFile(manifest.caption_path, "caption") : undefined;
+
+	const runId = `${profile.bucket}/${manifest.run_id}`;
+	const store = new AssetStore(runId);
+	const importedState = {
+		run_id: runId,
+		bucket: profile.bucket,
+		video_path: videoPath,
+		publish_video_path: videoPath,
+		thumbnail_path: thumbnailPath,
+		metadata: {
+			title: metadata.title,
+			description: metadata.description,
+			tags: metadata.tags,
+			thumbnail_title: metadata.thumbnail_title,
+		},
+		caption_path: captionPath,
+		source_manifest_path: manifestPath,
+		source_artifact_sha256: expectedVideoHash,
+		contains_synthetic_media: manifest.compliance?.contains_synthetic_media === true,
+		publish_at: manifest.publish_at || undefined,
+	} as Partial<AgentState> & Record<string, unknown>;
+	store.updateState(importedState as Partial<AgentState>);
+	fs.writeJsonSync(
+		path.join(store.runDir, "dancer_import.json"),
+		{
+			schema_version: 1,
+			imported_at: new Date().toISOString(),
+			manifest_path: manifestPath,
+			source_artifact_sha256: expectedVideoHash,
+			publish_video_path: videoPath,
+			thumbnail_path: thumbnailPath,
+			profile: profile.profileName,
+			channel_id: profile.expectedChannelId,
+			run_id: runId,
+		},
+		{ spaces: 2 },
+	);
+	console.log(JSON.stringify({ run_id: runId, run_dir: path.resolve(store.runDir), publish_video_path: videoPath, source_artifact_sha256: expectedVideoHash }));
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(error instanceof Error ? error.message : error);
+	process.exit(1);
+}

--- a/src/scripts/import_dancer_artifact.ts
+++ b/src/scripts/import_dancer_artifact.ts
@@ -1,15 +1,26 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import fs from "fs-extra";
-import { AssetStore, type AgentState } from "../io/core.js";
 import { getYouTubeProfile } from "../domain/youtube_profiles.js";
+import { type AgentState, AssetStore } from "../io/core.js";
 
 type DancerManifest = {
 	schema_version: number;
 	run_id: string;
 	selected?: { video_path?: string; video_sha256?: string };
-	thumbnail?: { path?: string; size_bytes?: number; mime_type?: string; source_video_sha256?: string };
-	metadata?: { title?: string; description?: string; tags?: string[]; thumbnail_title?: string; path?: string };
+	thumbnail?: {
+		path?: string;
+		size_bytes?: number;
+		mime_type?: string;
+		source_video_sha256?: string;
+	};
+	metadata?: {
+		title?: string;
+		description?: string;
+		tags?: string[];
+		thumbnail_title?: string;
+		path?: string;
+	};
 	caption_path?: string | null;
 	publish_at?: string | null;
 	compliance?: { passed?: boolean; contains_synthetic_media?: boolean };
@@ -24,7 +35,8 @@ function sha256(filePath: string): string {
 function requireFile(rawPath: string | undefined, label: string): string {
 	if (!rawPath) throw new Error(`Dancer manifest is missing ${label}`);
 	const resolved = path.resolve(rawPath);
-	if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) throw new Error(`${label} does not exist: ${resolved}`);
+	if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile())
+		throw new Error(`${label} does not exist: ${resolved}`);
 	return resolved;
 }
 
@@ -32,29 +44,56 @@ function main() {
 	const manifestArg = process.argv[2];
 	const profileArg = process.argv[3];
 	if (!manifestArg || !profileArg) {
-		throw new Error("Usage: bun src/scripts/import_dancer_artifact.ts <manifest.json> <byosan|yawa|humanity>");
+		throw new Error(
+			"Usage: bun src/scripts/import_dancer_artifact.ts <manifest.json> <byosan|yawa|humanity>",
+		);
 	}
 	process.env.YOUTUBE_CHANNEL_PROFILE = profileArg;
 	const profile = getYouTubeProfile(profileArg);
 	const manifestPath = requireFile(manifestArg, "manifest path");
 	const manifest = fs.readJsonSync(manifestPath) as DancerManifest;
-	if (manifest.schema_version !== 1) throw new Error(`Unsupported dancer manifest schema: ${manifest.schema_version}`);
-	if (!manifest.run_id || !/^dancer-[a-f0-9]{20}$/.test(manifest.run_id)) throw new Error(`Invalid dancer run id: ${manifest.run_id || "missing"}`);
-	if (manifest.compliance?.passed !== true) throw new Error("Dancer manifest did not pass the rights/provenance compliance gate");
-	const videoPath = requireFile(manifest.selected?.video_path, "selected video");
+	if (manifest.schema_version !== 1)
+		throw new Error(
+			`Unsupported dancer manifest schema: ${manifest.schema_version}`,
+		);
+	if (!manifest.run_id || !/^dancer-[a-f0-9]{20}$/.test(manifest.run_id))
+		throw new Error(`Invalid dancer run id: ${manifest.run_id || "missing"}`);
+	if (manifest.compliance?.passed !== true)
+		throw new Error(
+			"Dancer manifest did not pass the rights/provenance compliance gate",
+		);
+	const videoPath = requireFile(
+		manifest.selected?.video_path,
+		"selected video",
+	);
 	const expectedVideoHash = manifest.selected?.video_sha256;
-	if (!expectedVideoHash || sha256(videoPath) !== expectedVideoHash) throw new Error("Dancer selected video SHA-256 does not match manifest");
-	if (manifest.thumbnail?.source_video_sha256 !== expectedVideoHash) throw new Error("Dancer thumbnail provenance does not match selected video hash");
+	if (!expectedVideoHash || sha256(videoPath) !== expectedVideoHash)
+		throw new Error("Dancer selected video SHA-256 does not match manifest");
+	if (manifest.thumbnail?.source_video_sha256 !== expectedVideoHash)
+		throw new Error(
+			"Dancer thumbnail provenance does not match selected video hash",
+		);
 	const thumbnailPath = requireFile(manifest.thumbnail?.path, "thumbnail");
 	const thumbnailSize = fs.statSync(thumbnailPath).size;
-	if (thumbnailSize > 2 * 1024 * 1024) throw new Error(`Dancer thumbnail exceeds YouTube 2 MB limit: ${thumbnailSize} bytes`);
+	if (thumbnailSize > 2 * 1024 * 1024)
+		throw new Error(
+			`Dancer thumbnail exceeds YouTube 2 MB limit: ${thumbnailSize} bytes`,
+		);
 	const thumbnailExtension = path.extname(thumbnailPath).toLowerCase();
-	if (![".jpg", ".jpeg", ".png"].includes(thumbnailExtension)) throw new Error(`Unsupported thumbnail format: ${thumbnailExtension}`);
+	if (![".jpg", ".jpeg", ".png"].includes(thumbnailExtension))
+		throw new Error(`Unsupported thumbnail format: ${thumbnailExtension}`);
 	const metadata = manifest.metadata;
-	if (!metadata?.title || !metadata.description || !metadata.thumbnail_title || !Array.isArray(metadata.tags)) {
+	if (
+		!metadata?.title ||
+		!metadata.description ||
+		!metadata.thumbnail_title ||
+		!Array.isArray(metadata.tags)
+	) {
 		throw new Error("Dancer manifest metadata is incomplete");
 	}
-	const captionPath = manifest.caption_path ? requireFile(manifest.caption_path, "caption") : undefined;
+	const captionPath = manifest.caption_path
+		? requireFile(manifest.caption_path, "caption")
+		: undefined;
 
 	const runId = `${profile.bucket}/${manifest.run_id}`;
 	const store = new AssetStore(runId);
@@ -73,7 +112,8 @@ function main() {
 		caption_path: captionPath,
 		source_manifest_path: manifestPath,
 		source_artifact_sha256: expectedVideoHash,
-		contains_synthetic_media: manifest.compliance?.contains_synthetic_media === true,
+		contains_synthetic_media:
+			manifest.compliance?.contains_synthetic_media === true,
 		publish_at: manifest.publish_at || undefined,
 	} as Partial<AgentState> & Record<string, unknown>;
 	store.updateState(importedState as Partial<AgentState>);
@@ -92,7 +132,14 @@ function main() {
 		},
 		{ spaces: 2 },
 	);
-	console.log(JSON.stringify({ run_id: runId, run_dir: path.resolve(store.runDir), publish_video_path: videoPath, source_artifact_sha256: expectedVideoHash }));
+	console.log(
+		JSON.stringify({
+			run_id: runId,
+			run_dir: path.resolve(store.runDir),
+			publish_video_path: videoPath,
+			source_artifact_sha256: expectedVideoHash,
+		}),
+	);
 }
 
 try {

--- a/src/scripts/ingest_youtube_analytics.ts
+++ b/src/scripts/ingest_youtube_analytics.ts
@@ -1,103 +1,138 @@
-import { Database } from "bun:sqlite";
 import path from "node:path";
+import { Database } from "bun:sqlite";
 import dotenv from "dotenv";
 import fs from "fs-extra";
 import { google } from "googleapis";
 import {
 	YOUTUBE_PROFILES,
 	type YouTubeProfileName,
+	hydrateOAuthCredentials,
 } from "../domain/youtube_profiles.js";
 
 const ROOT = process.cwd();
 const DB_FILE = "db/evolution.db";
+const METRICS = [
+	"views",
+	"engagedViews",
+	"estimatedMinutesWatched",
+	"averageViewDuration",
+	"averageViewPercentage",
+	"likes",
+	"comments",
+	"shares",
+	"subscribersGained",
+	"subscribersLost",
+] as const;
 
-// Recorded baseline for 100x growth tracking
-export const RECORDED_BASELINE = {
-	byosan_money: {
-		views_24h_median: 15,
-		views_7d_median: 75,
-		watch_time_minutes_median: 1.5,
-		retention_percentage_median: 35.0,
-		satisfaction_score_median: 0.02,
-	},
-	humanity_observatory: {
-		views_24h_median: 8,
-		views_7d_median: 40,
-		watch_time_minutes_median: 0.8,
-		retention_percentage_median: 45.0,
-		satisfaction_score_median: 0.04,
-	},
+type AnalyticsWindow = "published_day" | "first_7d";
+
+type PublishedVideo = {
+	runId: string;
+	runDir: string;
+	channelId: string;
+	videoId: string;
+	publishedAt: string;
+	bucket: string;
+	privacyStatus: string;
 };
 
 export interface AnalyticsRecord {
 	video_id: string;
 	channel_id: string;
-	age_window: "24h" | "7d";
+	age_window: AnalyticsWindow;
 	views: number;
+	engaged_views: number;
 	watch_time_minutes: number;
 	average_view_duration_seconds: number;
 	average_view_percentage: number;
 	likes: number;
 	comments: number;
 	shares: number;
-	subscribers_net: number;
-	satisfaction_score: number;
+	subscribers_gained: number;
+	subscribers_lost: number;
 }
 
-// Calculate satisfaction proxy: (likes + comments * 2 + shares * 5) / views
-export function calculateSatisfactionScore(
-	likes: number,
-	comments: number,
-	shares: number,
-	views: number,
-): number {
-	if (views === 0) return 0;
-	return Number(((likes + comments * 2 + shares * 5) / views).toFixed(4));
+function isoDate(date: Date): string {
+	return date.toISOString().slice(0, 10);
 }
 
-// Scans all run dirs for publish receipts
-export function discoverVideos(baseDir = process.cwd()): Array<{
-	runId: string;
-	channelId: string;
-	videoId: string;
-	publishedAt: string;
-	bucket: string;
-}> {
-	const videos: Array<{
-		runId: string;
-		channelId: string;
-		videoId: string;
-		publishedAt: string;
-		bucket: string;
+function addUtcDays(date: Date, days: number): Date {
+	const copy = new Date(date.getTime());
+	copy.setUTCDate(copy.getUTCDate() + days);
+	return copy;
+}
+
+export function eligibleWindows(
+	publishedAt: string,
+	now = new Date(),
+): Array<{ name: AnalyticsWindow; startDate: string; endDate: string }> {
+	const published = new Date(publishedAt);
+	if (!Number.isFinite(published.getTime())) return [];
+	const ageHours = (now.getTime() - published.getTime()) / 3_600_000;
+	const startDate = isoDate(published);
+	const windows: Array<{
+		name: AnalyticsWindow;
+		startDate: string;
+		endDate: string;
 	}> = [];
+	// Analytics is date-based and can lag. Do not label this as an exact rolling 24h window.
+	if (ageHours >= 48) {
+		windows.push({ name: "published_day", startDate, endDate: startDate });
+	}
+	if (ageHours >= 8 * 24) {
+		windows.push({
+			name: "first_7d",
+			startDate,
+			endDate: isoDate(addUtcDays(published, 6)),
+		});
+	}
+	return windows;
+}
+
+function profileForBucket(bucket: string): YouTubeProfileName {
+	if (bucket.includes("humanity")) return "humanity";
+	if (bucket.includes("yawa")) return "yawa";
+	return "byosan";
+}
+
+export function discoverVideos(baseDir = process.cwd()): PublishedVideo[] {
+	const videos: PublishedVideo[] = [];
 	const runsDir = path.join(baseDir, "runs");
 	if (!fs.existsSync(runsDir)) return videos;
-
-	const buckets = fs.readdirSync(runsDir);
-	for (const bucket of buckets) {
+	for (const bucket of fs.readdirSync(runsDir)) {
 		const bucketDir = path.join(runsDir, bucket);
 		if (!fs.statSync(bucketDir).isDirectory()) continue;
-
-		const runNames = fs.readdirSync(bucketDir);
-		for (const runName of runNames) {
+		for (const runName of fs.readdirSync(bucketDir)) {
 			const runDir = path.join(bucketDir, runName);
 			if (!fs.statSync(runDir).isDirectory()) continue;
-
 			const receiptPath = path.join(runDir, "publish", "receipt.json");
-			if (fs.existsSync(receiptPath)) {
-				try {
-					const receipt = fs.readJsonSync(receiptPath);
-					const youtube = receipt.youtube;
-					if (youtube?.video_id && youtube?.published_at) {
-						videos.push({
-							runId: `${bucket}/${runName}`,
-							channelId: youtube.channel_id || "",
-							videoId: youtube.video_id,
-							publishedAt: youtube.published_at,
-							bucket,
-						});
-					}
-				} catch {}
+			if (!fs.existsSync(receiptPath)) continue;
+			try {
+				const receipt = fs.readJsonSync(receiptPath) as {
+					youtube?: {
+						video_id?: string;
+						channel_id?: string;
+						published_at?: string;
+						privacy_status?: string;
+					};
+				};
+				const youtube = receipt.youtube;
+				if (!youtube?.video_id || !youtube.channel_id || !youtube.published_at) continue;
+				const schedulePath = path.join(runDir, "publish", "schedule_attestation.json");
+				const schedule = fs.existsSync(schedulePath)
+					? (fs.readJsonSync(schedulePath) as { publish_at?: string })
+					: {};
+				videos.push({
+					runId: `${bucket}/${runName}`,
+					runDir,
+					channelId: youtube.channel_id,
+					videoId: youtube.video_id,
+					publishedAt: schedule.publish_at || youtube.published_at,
+					bucket,
+					privacyStatus: youtube.privacy_status || "unknown",
+				});
+			} catch (error) {
+				console.warn(`Skipping unreadable receipt ${receiptPath}: ${(error as Error).message}`);
 			}
 		}
 	}
@@ -106,245 +141,204 @@ export function discoverVideos(baseDir = process.cwd()): Array<{
 
 async function getOAuthClient(profileName: YouTubeProfileName) {
 	const profile = YOUTUBE_PROFILES[profileName];
-	const envPath = path.join(process.cwd(), profile.envFile);
-	if (!fs.existsSync(envPath)) {
-		throw new Error(`Profile env file missing: ${profile.envFile}`);
-	}
-
+	const envPath = path.join(ROOT, profile.envFile);
+	if (!fs.existsSync(envPath)) throw new Error(`Profile env file missing: ${profile.envFile}`);
 	dotenv.config({ path: envPath, override: true });
 	const clientId = process.env.YOUTUBE_CLIENT_ID;
 	const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
-	const refreshToken = process.env.YOUTUBE_REFRESH_TOKEN;
-
-	if (!clientId || !clientSecret || !refreshToken) {
-		throw new Error(
-			`Missing OAuth config in env file ${profile.envFile} (Client ID, Secret, or Refresh Token missing)`,
-		);
+	if (!clientId || !clientSecret) {
+		throw new Error(`Missing OAuth client config in ${profile.envFile}`);
 	}
-
 	const auth = new google.auth.OAuth2(
 		clientId,
 		clientSecret,
-		process.env.YOUTUBE_REDIRECT_URI || "http://localhost:3000/oauth2callback",
+		process.env.YOUTUBE_REDIRECT_URI || "http://localhost:3310/oauth2callback",
 	);
-	auth.setCredentials({ refresh_token: refreshToken });
+	await hydrateOAuthCredentials(auth, profile);
 	return { auth, profile };
 }
 
-// Ingests analytics data for a specific video and channel
+async function verifyAuthorizationAndVideo(
+	auth: InstanceType<typeof google.auth.OAuth2>,
+	expectedChannelId: string,
+	videoId: string,
+): Promise<boolean> {
+	const youtube = google.youtube({ version: "v3", auth });
+	const channels = await youtube.channels.list({ mine: true, part: ["id"], maxResults: 1 });
+	const actualChannelId = channels.data.items?.[0]?.id;
+	if (actualChannelId !== expectedChannelId) {
+		throw new Error(
+			`Analytics authorization channel mismatch: expected ${expectedChannelId}, got ${actualChannelId || "missing"}`,
+		);
+	}
+	const videos = await youtube.videos.list({ part: ["id", "status"], id: [videoId] });
+	return Boolean(videos.data.items?.[0]);
+}
+
 async function fetchAnalytics(
 	auth: InstanceType<typeof google.auth.OAuth2>,
 	channelId: string,
 	videoId: string,
-	ageWindow: "24h" | "7d",
-): Promise<Omit<AnalyticsRecord, "satisfaction_score">> {
+	window: { name: AnalyticsWindow; startDate: string; endDate: string },
+	runDir: string,
+): Promise<AnalyticsRecord> {
 	const youtubeAnalytics = google.youtubeAnalytics({ version: "v2", auth });
+	const query = {
+		ids: `channel==${channelId}`,
+		startDate: window.startDate,
+		endDate: window.endDate,
+		metrics: METRICS.join(","),
+		dimensions: "video",
+		filters: `video==${videoId}`,
+	};
+	const response = await youtubeAnalytics.reports.query(query);
+	const raw = {
+		source: "YouTube Analytics API reports.query",
+		retrieved_at: new Date().toISOString(),
+		query,
+		response: response.data,
+	};
+	const analyticsDir = path.join(runDir, "analytics");
+	fs.ensureDirSync(analyticsDir);
+	fs.writeJsonSync(path.join(analyticsDir, `${window.name}.json`), raw, { spaces: 2 });
 
-	try {
-		const response = await youtubeAnalytics.reports.query({
-			ids: `channel==${channelId}`,
-			startDate: "2000-01-01",
-			endDate: new Intl.DateTimeFormat("en-CA", {
-				timeZone: "Asia/Tokyo",
-			}).format(new Date()),
-			metrics:
-				"views,estimatedMinutesWatched,averageViewDuration,likes,comments,shares,subscriberCountGained,subscriberCountLost",
-			dimensions: "video",
-			filters: `video==${videoId}`,
-		});
+	const row = response.data.rows?.[0];
+	if (!row) throw new Error(`No analytics data returned for ${videoId} / ${window.name}`);
+	return {
+		video_id: videoId,
+		channel_id: channelId,
+		age_window: window.name,
+		views: Number(row[1] || 0),
+		engaged_views: Number(row[2] || 0),
+		watch_time_minutes: Number(row[3] || 0),
+		average_view_duration_seconds: Number(row[4] || 0),
+		average_view_percentage: Number(row[5] || 0),
+		likes: Number(row[6] || 0),
+		comments: Number(row[7] || 0),
+		shares: Number(row[8] || 0),
+		subscribers_gained: Number(row[9] || 0),
+		subscribers_lost: Number(row[10] || 0),
+	};
+}
 
-		const rows = response.data.rows;
-		if (!rows || rows.length === 0) {
-			throw new Error(`No analytics data returned for video ${videoId}`);
-		}
-
-		const row = rows[0];
-		if (!row) {
-			throw new Error(`Row data empty for video ${videoId}`);
-		}
-		const views = Number(row[1] || 0);
-		const watchTimeMinutes = Number(row[2] || 0);
-		const averageViewDurationSeconds = Number(row[3] || 0);
-		const likes = Number(row[4] || 0);
-		const comments = Number(row[5] || 0);
-		const shares = Number(row[6] || 0);
-		const gained = Number(row[7] || 0);
-		const lost = Number(row[8] || 0);
-
-		// Get video details for duration mapping to average view percentage
-		const youtube = google.youtube({ version: "v3", auth });
-		const details = await youtube.videos.list({
-			part: ["contentDetails"],
-			id: [videoId],
-		});
-		const durationISO = details.data.items?.[0]?.contentDetails?.duration || "";
-		let videoDurationSeconds = 60;
-		const durationMatch = durationISO.match(
-			/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/,
-		);
-		if (durationMatch) {
-			const hours = Number(durationMatch[1] || 0);
-			const minutes = Number(durationMatch[2] || 0);
-			const seconds = Number(durationMatch[3] || 0);
-			videoDurationSeconds = hours * 3600 + minutes * 60 + seconds;
-		}
-
-		const averageViewPercentage =
-			videoDurationSeconds > 0
-				? Number(
-						((averageViewDurationSeconds / videoDurationSeconds) * 100).toFixed(
-							2,
-						),
-					)
-				: 0;
-
-		return {
-			video_id: videoId,
-			channel_id: channelId,
-			age_window: ageWindow,
-			views,
-			watch_time_minutes: watchTimeMinutes,
-			average_view_duration_seconds: averageViewDurationSeconds,
-			average_view_percentage: averageViewPercentage,
-			likes,
-			comments,
-			shares,
-			subscribers_net: gained - lost,
-		};
-	} catch (error: unknown) {
-		const e = error as Error & { code?: number };
-		if (e.message?.includes("insufficientPermissions") || e.code === 403) {
-			throw new Error(
-				`YouTube Analytics API call failed due to INSUFFICIENT PERMISSIONS. Please ensure your OAuth token has the required scope: 'https://www.googleapis.com/auth/yt-analytics.readonly'. Original error: ${e.message}`,
-			);
-		}
-		throw e;
+function ensureAnalyticsColumns(db: Database) {
+	const columns = new Set(
+		(db.query("PRAGMA table_info(youtube_analytics)").all() as Array<{ name: string }>).map(
+			(row) => row.name,
+		),
+	);
+	for (const [name, type] of [
+		["engaged_views", "INTEGER"],
+		["subscribers_gained", "INTEGER"],
+		["subscribers_lost", "INTEGER"],
+	] as const) {
+		if (!columns.has(name)) db.exec(`ALTER TABLE youtube_analytics ADD COLUMN ${name} ${type}`);
 	}
 }
 
 export function saveAnalyticsRecord(db: Database, record: AnalyticsRecord) {
+	ensureAnalyticsColumns(db);
 	const insert = db.prepare(`
 		INSERT INTO youtube_analytics (
-			video_id, channel_id, age_window, views, watch_time_minutes,
-			average_view_duration_seconds, average_view_percentage,
-			likes, comments, shares, subscribers_net, satisfaction_score, recorded_at
+			video_id, channel_id, age_window, views, engaged_views,
+			watch_time_minutes, average_view_duration_seconds, average_view_percentage,
+			likes, comments, shares, subscribers_gained, subscribers_lost,
+			subscribers_net, satisfaction_score, recorded_at
 		) VALUES (
-			$video_id, $channel_id, $age_window, $views, $watch_time_minutes,
-			$average_view_duration_seconds, $average_view_percentage,
-			$likes, $comments, $shares, $subscribers_net, $satisfaction_score, datetime('now', 'localtime')
+			$video_id, $channel_id, $age_window, $views, $engaged_views,
+			$watch_time_minutes, $average_view_duration_seconds, $average_view_percentage,
+			$likes, $comments, $shares, $subscribers_gained, $subscribers_lost,
+			NULL, NULL, datetime('now')
 		) ON CONFLICT(video_id, age_window) DO UPDATE SET
 			views = excluded.views,
+			engaged_views = excluded.engaged_views,
 			watch_time_minutes = excluded.watch_time_minutes,
 			average_view_duration_seconds = excluded.average_view_duration_seconds,
 			average_view_percentage = excluded.average_view_percentage,
 			likes = excluded.likes,
 			comments = excluded.comments,
 			shares = excluded.shares,
-			subscribers_net = excluded.subscribers_net,
-			satisfaction_score = excluded.satisfaction_score,
-			recorded_at = datetime('now', 'localtime')
+			subscribers_gained = excluded.subscribers_gained,
+			subscribers_lost = excluded.subscribers_lost,
+			subscribers_net = NULL,
+			satisfaction_score = NULL,
+			recorded_at = datetime('now')
 	`);
-
 	insert.run({
 		$video_id: record.video_id,
 		$channel_id: record.channel_id,
 		$age_window: record.age_window,
 		$views: record.views,
+		$engaged_views: record.engaged_views,
 		$watch_time_minutes: record.watch_time_minutes,
 		$average_view_duration_seconds: record.average_view_duration_seconds,
 		$average_view_percentage: record.average_view_percentage,
 		$likes: record.likes,
 		$comments: record.comments,
 		$shares: record.shares,
-		$subscribers_net: record.subscribers_net,
-		$satisfaction_score: record.satisfaction_score,
+		$subscribers_gained: record.subscribers_gained,
+		$subscribers_lost: record.subscribers_lost,
 	});
 }
 
 async function main() {
-	console.log("=== YouTube Analytics Ingestion & Feedback Loop ===");
-
+	console.log("=== YouTube Analytics ingestion (raw API metrics only) ===");
 	const videos = discoverVideos();
 	if (videos.length === 0) {
-		console.log("No published videos found in runs directory. Scan complete.");
+		console.log("No published videos found in runs directory.");
 		return;
 	}
-
 	const db = new Database(DB_FILE);
-	const now = new Date();
-
-	for (const video of videos) {
-		const publishTime = new Date(video.publishedAt);
-		const ageMs = now.getTime() - publishTime.getTime();
-		const ageHours = ageMs / (1000 * 60 * 60);
-
-		let ageWindow: "24h" | "7d" | null = null;
-		if (ageHours >= 168) {
-			ageWindow = "7d";
-		} else if (ageHours >= 24) {
-			ageWindow = "24h";
+	try {
+		for (const video of videos) {
+			const windows = eligibleWindows(video.publishedAt);
+			if (windows.length === 0) continue;
+			const profileName = profileForBucket(video.bucket);
+			try {
+				const { auth, profile } = await getOAuthClient(profileName);
+				if (video.channelId !== profile.expectedChannelId) {
+					throw new Error(
+						`Receipt channel mismatch for ${video.videoId}: expected ${profile.expectedChannelId}, got ${video.channelId}`,
+					);
+				}
+				const exists = await verifyAuthorizationAndVideo(
+					auth,
+					profile.expectedChannelId,
+					video.videoId,
+				);
+				if (!exists) {
+					db.prepare("DELETE FROM youtube_analytics WHERE video_id = ?").run(video.videoId);
+					fs.removeSync(path.join(video.runDir, "analytics"));
+					console.warn(`Deleted stale analytics because video no longer exists: ${video.videoId}`);
+					continue;
+				}
+				for (const window of windows) {
+					const record = await fetchAnalytics(
+						auth,
+						profile.expectedChannelId,
+						video.videoId,
+						window,
+						video.runDir,
+					);
+					saveAnalyticsRecord(db, record);
+					console.log(
+						`[SUCCESS] ${video.videoId} ${window.name}: ${record.views} views, ${record.engaged_views} engaged views`,
+					);
+				}
+			} catch (error) {
+				console.error(
+					`[FAIL_CLOSED] ${video.videoId} (${profileName}): ${(error as Error).message}`,
+				);
+			}
 		}
-
-		if (!ageWindow) {
-			console.log(
-				`Video ${video.videoId} is too fresh (${ageHours.toFixed(1)}h old), skipping.`,
-			);
-			continue;
-		}
-
-		console.log(
-			`Processing video ${video.videoId} (${video.bucket}) for age window: ${ageWindow}`,
-		);
-
-		let profileName: YouTubeProfileName = "byosan";
-		if (video.bucket.includes("humanity")) {
-			profileName = "humanity";
-		} else if (video.bucket.includes("yawa")) {
-			profileName = "yawa";
-		}
-
-		try {
-			const { auth, profile } = await getOAuthClient(profileName);
-
-			console.log(
-				`Fetching YouTube Analytics API data for ${video.videoId} on channel ${profile.expectedChannelTitle}...`,
-			);
-			const metrics = await fetchAnalytics(
-				auth,
-				profile.expectedChannelId,
-				video.videoId,
-				ageWindow,
-			);
-			const satisfaction_score = calculateSatisfactionScore(
-				metrics.likes,
-				metrics.comments,
-				metrics.shares,
-				metrics.views,
-			);
-
-			const record: AnalyticsRecord = {
-				...metrics,
-				satisfaction_score,
-			};
-
-			saveAnalyticsRecord(db, record);
-			console.log(
-				`[SUCCESS] Stored analytics for video ${video.videoId}: ${record.views} views, satisfaction: ${record.satisfaction_score}`,
-			);
-		} catch (error: unknown) {
-			const e = error as Error & { code?: number };
-			console.error(
-				`[FAIL_CLOSED] Action required for video ${video.videoId} (${profileName}): ${e.message}`,
-			);
-			console.log(
-				"Documenting missing scope: 'https://www.googleapis.com/auth/yt-analytics.readonly' on OAuth authorization.",
-			);
-		}
+	} finally {
+		db.close();
 	}
-
-	db.close();
 }
 
-if (require.main === module) {
-	main().catch(console.error);
+if (import.meta.main) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exit(1);
+	});
 }

--- a/src/scripts/ingest_youtube_analytics.ts
+++ b/src/scripts/ingest_youtube_analytics.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { Database } from "bun:sqlite";
+import path from "node:path";
 import dotenv from "dotenv";
 import fs from "fs-extra";
 import { google } from "googleapis";
@@ -117,8 +117,13 @@ export function discoverVideos(baseDir = process.cwd()): PublishedVideo[] {
 					};
 				};
 				const youtube = receipt.youtube;
-				if (!youtube?.video_id || !youtube.channel_id || !youtube.published_at) continue;
-				const schedulePath = path.join(runDir, "publish", "schedule_attestation.json");
+				if (!youtube?.video_id || !youtube.channel_id || !youtube.published_at)
+					continue;
+				const schedulePath = path.join(
+					runDir,
+					"publish",
+					"schedule_attestation.json",
+				);
 				const schedule = fs.existsSync(schedulePath)
 					? (fs.readJsonSync(schedulePath) as { publish_at?: string })
 					: {};
@@ -132,7 +137,9 @@ export function discoverVideos(baseDir = process.cwd()): PublishedVideo[] {
 					privacyStatus: youtube.privacy_status || "unknown",
 				});
 			} catch (error) {
-				console.warn(`Skipping unreadable receipt ${receiptPath}: ${(error as Error).message}`);
+				console.warn(
+					`Skipping unreadable receipt ${receiptPath}: ${(error as Error).message}`,
+				);
 			}
 		}
 	}
@@ -142,7 +149,8 @@ export function discoverVideos(baseDir = process.cwd()): PublishedVideo[] {
 async function getOAuthClient(profileName: YouTubeProfileName) {
 	const profile = YOUTUBE_PROFILES[profileName];
 	const envPath = path.join(ROOT, profile.envFile);
-	if (!fs.existsSync(envPath)) throw new Error(`Profile env file missing: ${profile.envFile}`);
+	if (!fs.existsSync(envPath))
+		throw new Error(`Profile env file missing: ${profile.envFile}`);
 	dotenv.config({ path: envPath, override: true });
 	const clientId = process.env.YOUTUBE_CLIENT_ID;
 	const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
@@ -164,14 +172,21 @@ async function verifyAuthorizationAndVideo(
 	videoId: string,
 ): Promise<boolean> {
 	const youtube = google.youtube({ version: "v3", auth });
-	const channels = await youtube.channels.list({ mine: true, part: ["id"], maxResults: 1 });
+	const channels = await youtube.channels.list({
+		mine: true,
+		part: ["id"],
+		maxResults: 1,
+	});
 	const actualChannelId = channels.data.items?.[0]?.id;
 	if (actualChannelId !== expectedChannelId) {
 		throw new Error(
 			`Analytics authorization channel mismatch: expected ${expectedChannelId}, got ${actualChannelId || "missing"}`,
 		);
 	}
-	const videos = await youtube.videos.list({ part: ["id", "status"], id: [videoId] });
+	const videos = await youtube.videos.list({
+		part: ["id", "status"],
+		id: [videoId],
+	});
 	return Boolean(videos.data.items?.[0]);
 }
 
@@ -200,10 +215,15 @@ async function fetchAnalytics(
 	};
 	const analyticsDir = path.join(runDir, "analytics");
 	fs.ensureDirSync(analyticsDir);
-	fs.writeJsonSync(path.join(analyticsDir, `${window.name}.json`), raw, { spaces: 2 });
+	fs.writeJsonSync(path.join(analyticsDir, `${window.name}.json`), raw, {
+		spaces: 2,
+	});
 
 	const row = response.data.rows?.[0];
-	if (!row) throw new Error(`No analytics data returned for ${videoId} / ${window.name}`);
+	if (!row)
+		throw new Error(
+			`No analytics data returned for ${videoId} / ${window.name}`,
+		);
 	return {
 		video_id: videoId,
 		channel_id: channelId,
@@ -223,16 +243,19 @@ async function fetchAnalytics(
 
 function ensureAnalyticsColumns(db: Database) {
 	const columns = new Set(
-		(db.query("PRAGMA table_info(youtube_analytics)").all() as Array<{ name: string }>).map(
-			(row) => row.name,
-		),
+		(
+			db.query("PRAGMA table_info(youtube_analytics)").all() as Array<{
+				name: string;
+			}>
+		).map((row) => row.name),
 	);
 	for (const [name, type] of [
 		["engaged_views", "INTEGER"],
 		["subscribers_gained", "INTEGER"],
 		["subscribers_lost", "INTEGER"],
 	] as const) {
-		if (!columns.has(name)) db.exec(`ALTER TABLE youtube_analytics ADD COLUMN ${name} ${type}`);
+		if (!columns.has(name))
+			db.exec(`ALTER TABLE youtube_analytics ADD COLUMN ${name} ${type}`);
 	}
 }
 
@@ -307,9 +330,13 @@ async function main() {
 					video.videoId,
 				);
 				if (!exists) {
-					db.prepare("DELETE FROM youtube_analytics WHERE video_id = ?").run(video.videoId);
+					db.prepare("DELETE FROM youtube_analytics WHERE video_id = ?").run(
+						video.videoId,
+					);
 					fs.removeSync(path.join(video.runDir, "analytics"));
-					console.warn(`Deleted stale analytics because video no longer exists: ${video.videoId}`);
+					console.warn(
+						`Deleted stale analytics because video no longer exists: ${video.videoId}`,
+					);
 					continue;
 				}
 				for (const window of windows) {

--- a/src/scripts/youtube_oauth.ts
+++ b/src/scripts/youtube_oauth.ts
@@ -14,23 +14,15 @@ import {
 } from "../domain/youtube_profiles.js";
 
 const envFile = process.env.ENV_FILE?.trim();
-if (!envFile) {
-	throw new Error("ENV_FILE is required for YouTube OAuth setup");
-}
-
-const envFilePath = path.isAbsolute(envFile)
-	? envFile
-	: path.join(process.cwd(), envFile);
-
+if (!envFile) throw new Error("ENV_FILE is required for YouTube OAuth setup");
+const envFilePath = path.isAbsolute(envFile) ? envFile : path.join(process.cwd(), envFile);
 dotenv.config({ path: envFilePath, override: true });
-
 const verifyOnly = process.argv.includes("--verify-only");
 
 async function waitForOAuthCode(redirectUri: string): Promise<string> {
 	const url = new URL(redirectUri);
 	const port = Number(url.port || (url.protocol === "https:" ? 443 : 80));
 	const pathname = url.pathname || "/oauth2callback";
-
 	return await new Promise<string>((resolve, reject) => {
 		const server = http.createServer((req, res) => {
 			try {
@@ -39,17 +31,14 @@ async function waitForOAuthCode(redirectUri: string): Promise<string> {
 					res.end("Missing callback URL");
 					return;
 				}
-
 				const callbackUrl = new URL(req.url, `http://127.0.0.1:${port}`);
 				if (callbackUrl.pathname !== pathname) {
 					res.statusCode = 404;
 					res.end("Not Found");
 					return;
 				}
-
 				const code = callbackUrl.searchParams.get("code");
 				const error = callbackUrl.searchParams.get("error");
-
 				if (error) {
 					res.statusCode = 400;
 					res.end(`OAuth error: ${error}`);
@@ -57,7 +46,6 @@ async function waitForOAuthCode(redirectUri: string): Promise<string> {
 					server.close();
 					return;
 				}
-
 				if (!code) {
 					res.statusCode = 400;
 					res.end("Missing OAuth code");
@@ -65,29 +53,22 @@ async function waitForOAuthCode(redirectUri: string): Promise<string> {
 					server.close();
 					return;
 				}
-
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(
-					"<html><body>Authentication successful. You can close this tab.</body></html>",
-				);
+				res.end("<html><body>Authentication successful. You can close this tab.</body></html>");
 				server.close(() => resolve(code));
 			} catch (error) {
 				reject(error);
 				server.close();
 			}
 		});
-
 		server.on("error", reject);
-		server.listen(port, () => {
-			console.log(`OAuth callback listening on :${port}`);
-		});
+		server.listen(port, () => console.log(`OAuth callback listening on :${port}`));
 	});
 }
 
 async function main() {
 	const profile = getYouTubeProfile();
 	assertProfileEnvFile(profile, process.env.ENV_FILE);
-
 	const clientId = process.env.YOUTUBE_CLIENT_ID;
 	const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
 	if (!clientId || !clientSecret) {
@@ -95,14 +76,8 @@ async function main() {
 			`YouTube auth failed for profile '${profile.profileName}': YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET are required`,
 		);
 	}
-
 	const redirectUri = resolveYouTubeRedirectUri();
-	const auth = new google.auth.OAuth2({
-		clientId,
-		clientSecret,
-		redirectUri,
-	});
-
+	const auth = new google.auth.OAuth2({ clientId, clientSecret, redirectUri });
 	if (verifyOnly) {
 		await hydrateOAuthCredentials(auth, profile);
 		const result = await assertYouTubeChannelMatchesProfile(auth, profile);
@@ -119,21 +94,20 @@ async function main() {
 		scope: [
 			"https://www.googleapis.com/auth/youtube",
 			"https://www.googleapis.com/auth/youtube.upload",
+			"https://www.googleapis.com/auth/youtube.force-ssl",
+			"https://www.googleapis.com/auth/youtube.readonly",
+			"https://www.googleapis.com/auth/yt-analytics.readonly",
 		],
 	});
-
 	console.log("\nOPEN THIS URL:\n");
 	console.log(authUrl);
 	console.log("");
-
 	const code = await waitForOAuthCode(redirectUri);
 	const { tokens } = await auth.getToken(code);
 	auth.setCredentials(tokens);
-
 	const tokenPath = resolveTokenPath(profile);
 	await fs.ensureDir(path.dirname(tokenPath));
 	await fs.writeJson(tokenPath, tokens, { spaces: 2 });
-
 	const result = await assertYouTubeChannelMatchesProfile(auth, profile);
 	console.log("CHANNEL:");
 	console.log(result.actual.title);

--- a/src/scripts/youtube_oauth.ts
+++ b/src/scripts/youtube_oauth.ts
@@ -15,7 +15,9 @@ import {
 
 const envFile = process.env.ENV_FILE?.trim();
 if (!envFile) throw new Error("ENV_FILE is required for YouTube OAuth setup");
-const envFilePath = path.isAbsolute(envFile) ? envFile : path.join(process.cwd(), envFile);
+const envFilePath = path.isAbsolute(envFile)
+	? envFile
+	: path.join(process.cwd(), envFile);
 dotenv.config({ path: envFilePath, override: true });
 const verifyOnly = process.argv.includes("--verify-only");
 
@@ -54,7 +56,9 @@ async function waitForOAuthCode(redirectUri: string): Promise<string> {
 					return;
 				}
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end("<html><body>Authentication successful. You can close this tab.</body></html>");
+				res.end(
+					"<html><body>Authentication successful. You can close this tab.</body></html>",
+				);
 				server.close(() => resolve(code));
 			} catch (error) {
 				reject(error);
@@ -62,7 +66,9 @@ async function waitForOAuthCode(redirectUri: string): Promise<string> {
 			}
 		});
 		server.on("error", reject);
-		server.listen(port, () => console.log(`OAuth callback listening on :${port}`));
+		server.listen(port, () =>
+			console.log(`OAuth callback listening on :${port}`),
+		);
 	});
 }
 

--- a/tests/dancer_publication.test.ts
+++ b/tests/dancer_publication.test.ts
@@ -23,17 +23,30 @@ describe("dancer publication contract", () => {
 			bucket: "byosan_money",
 			publish_at: "2020-01-01T00:00:00Z",
 		} as AgentState & { publish_at: string };
-		expect(() => buildYouTubeStatus(state)).toThrow("publish_at must be in the future");
+		expect(() => buildYouTubeStatus(state)).toThrow(
+			"publish_at must be in the future",
+		);
 	});
 });
 
 describe("analytics windows", () => {
 	test("uses calendar windows instead of mislabeling all-time data as 24h", () => {
 		const published = "2026-08-01T10:00:00Z";
-		const windows = eligibleWindows(published, new Date("2026-08-10T12:00:00Z"));
+		const windows = eligibleWindows(
+			published,
+			new Date("2026-08-10T12:00:00Z"),
+		);
 		expect(windows).toEqual([
-			{ name: "published_day", startDate: "2026-08-01", endDate: "2026-08-01" },
-			{ name: "first_7d", startDate: "2026-08-01", endDate: "2026-08-07" },
+			{
+				name: "published_day",
+				startDate: "2026-08-01",
+				endDate: "2026-08-01",
+			},
+			{
+				name: "first_7d",
+				startDate: "2026-08-01",
+				endDate: "2026-08-07",
+			},
 		]);
 	});
 });

--- a/tests/dancer_publication.test.ts
+++ b/tests/dancer_publication.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { buildYouTubeStatus } from "../src/domain/dancer_publication.js";
+import type { AgentState } from "../src/domain/types.js";
+import { eligibleWindows } from "../src/scripts/ingest_youtube_analytics.js";
+
+describe("dancer publication contract", () => {
+	test("builds private staging status and preserves synthetic disclosure", () => {
+		const state = {
+			run_id: "byosan_money/dancer-0123456789abcdef0123",
+			bucket: "byosan_money",
+			contains_synthetic_media: false,
+		} as AgentState & { contains_synthetic_media: boolean };
+		expect(buildYouTubeStatus(state)).toEqual({
+			privacyStatus: "private",
+			selfDeclaredMadeForKids: false,
+			containsSyntheticMedia: false,
+		});
+	});
+
+	test("rejects scheduled publication in the past", () => {
+		const state = {
+			run_id: "byosan_money/dancer-0123456789abcdef0123",
+			bucket: "byosan_money",
+			publish_at: "2020-01-01T00:00:00Z",
+		} as AgentState & { publish_at: string };
+		expect(() => buildYouTubeStatus(state)).toThrow("publish_at must be in the future");
+	});
+});
+
+describe("analytics windows", () => {
+	test("uses calendar windows instead of mislabeling all-time data as 24h", () => {
+		const published = "2026-08-01T10:00:00Z";
+		const windows = eligibleWindows(published, new Date("2026-08-10T12:00:00Z"));
+		expect(windows).toEqual([
+			{ name: "published_day", startDate: "2026-08-01", endDate: "2026-08-01" },
+			{ name: "first_7d", startDate: "2026-08-01", endDate: "2026-08-07" },
+		]);
+	});
+});

--- a/tests/stability.test.ts
+++ b/tests/stability.test.ts
@@ -12,8 +12,12 @@ const TEMP_DIR = path.join(__dirname, "temp_stability_test_cwd");
 
 type AnalyticsRow = {
 	views: number;
+	engaged_views: number;
 	likes: number;
-	satisfaction_score: number;
+	subscribers_gained: number;
+	subscribers_lost: number;
+	subscribers_net: number | null;
+	satisfaction_score: number | null;
 };
 
 afterAll(async () => {
@@ -41,7 +45,6 @@ describe("Stability and Audit Helpers", () => {
 		const bucketDir = path.join(TEMP_DIR, "runs", "byosan_money");
 		await fs.ensureDir(bucketDir);
 
-		// Create test run dirs
 		await fs.ensureDir(path.join(bucketDir, "2026-07-05"));
 		await fs.ensureDir(path.join(bucketDir, "2026-07-05-june-swoon-femo"));
 		await fs.ensureDir(path.join(bucketDir, "2026-07-06"));
@@ -63,11 +66,9 @@ describe("Stability and Audit Helpers", () => {
 		);
 		await fs.ensureDir(runDir);
 
-		// Initially, it has nothing, so it should not be ready
 		expect(isEvidenceReady(runDir)).toBe(false);
 		expect(getMissingEvidence(runDir)).toContain("run_evidence.json");
 
-		// Add malformed run_evidence
 		const evidencePath = path.join(runDir, "run_evidence.json");
 		await fs.writeFile(evidencePath, "invalid json");
 		expect(isEvidenceReady(runDir)).toBe(false);
@@ -75,7 +76,6 @@ describe("Stability and Audit Helpers", () => {
 			"run_evidence.json (invalid JSON)",
 		);
 
-		// Add valid run_evidence with failed status
 		const failedEvidence = {
 			run_id: "byosan_money/2026-07-10-test",
 			bucket: "byosan_money",
@@ -88,7 +88,6 @@ describe("Stability and Audit Helpers", () => {
 		let missing = getMissingEvidence(runDir);
 		expect(missing).toContain("evidence status=failed disposition=fatal");
 
-		// Fix status but keep other stages missing
 		const successEvidence = {
 			run_id: "byosan_money/2026-07-10-test",
 			bucket: "byosan_money",
@@ -104,38 +103,22 @@ describe("Stability and Audit Helpers", () => {
 		expect(missing).toContain("research");
 		expect(missing).toContain("audit/report.json");
 
-		// Add research file
 		await fs.writeJson(path.join(runDir, "research.json"), {});
-		// Add video file
 		await fs.ensureDir(path.join(runDir, "video"));
 		await fs.writeFile(path.join(runDir, "video", "final_video.mp4"), "");
-		// Add publish receipt
 		await fs.ensureDir(path.join(runDir, "publish"));
 		await fs.writeJson(path.join(runDir, "publish", "receipt.json"), {});
-		// Add audit report
 		await fs.ensureDir(path.join(runDir, "audit"));
 		await fs.writeJson(path.join(runDir, "audit", "report.json"), {
 			decision: "PASS",
 		});
 
-		// Now it should be ready!
 		expect(isEvidenceReady(runDir)).toBe(true);
 		expect(getMissingEvidence(runDir).length).toBe(0);
 	});
 });
 
 describe("YouTube Analytics Seam", () => {
-	test("calculateSatisfactionScore calculates proxy value correctly", () => {
-		const {
-			calculateSatisfactionScore,
-		} = require("../src/scripts/ingest_youtube_analytics.ts");
-		// likes=10, comments=5, shares=2, views=100
-		// score = (10 + 5*2 + 2*5) / 100 = (10 + 10 + 10) / 100 = 0.3
-		expect(calculateSatisfactionScore(10, 5, 2, 100)).toBe(0.3);
-		expect(calculateSatisfactionScore(0, 0, 0, 100)).toBe(0);
-		expect(calculateSatisfactionScore(10, 5, 2, 0)).toBe(0);
-	});
-
 	test("discoverVideos finds receipts in mock run directories", async () => {
 		const {
 			discoverVideos,
@@ -160,7 +143,7 @@ describe("YouTube Analytics Seam", () => {
 		expect(match?.channelId).toBe("UCYtjO-PYBfdG3MuPLXfhA-Q");
 	});
 
-	test("saveAnalyticsRecord inserts and updates SQLite records", async () => {
+	test("saveAnalyticsRecord persists only raw official metrics", async () => {
 		const {
 			saveAnalyticsRecord,
 		} = require("../src/scripts/ingest_youtube_analytics.ts");
@@ -168,7 +151,6 @@ describe("YouTube Analytics Seam", () => {
 		const testDbPath = path.join(TEMP_DIR, "test_evolution.db");
 
 		const db = new Database(testDbPath);
-		// Create the table
 		db.exec(`
 			CREATE TABLE IF NOT EXISTS youtube_analytics (
 				video_id TEXT NOT NULL,
@@ -191,16 +173,17 @@ describe("YouTube Analytics Seam", () => {
 		const record = {
 			video_id: "XYZ789",
 			channel_id: "UCYtjO-PYBfdG3MuPLXfhA-Q",
-			age_window: "24h" as const,
+			age_window: "published_day" as const,
 			views: 150,
+			engaged_views: 140,
 			watch_time_minutes: 4.5,
 			average_view_duration_seconds: 1.8,
 			average_view_percentage: 45.0,
 			likes: 12,
 			comments: 3,
 			shares: 1,
-			subscribers_net: 5,
-			satisfaction_score: 0.155,
+			subscribers_gained: 5,
+			subscribers_lost: 1,
 		};
 
 		saveAnalyticsRecord(db, record);
@@ -210,10 +193,13 @@ describe("YouTube Analytics Seam", () => {
 			.get() as AnalyticsRow;
 		expect(row).toBeDefined();
 		expect(row.views).toBe(150);
+		expect(row.engaged_views).toBe(140);
 		expect(row.likes).toBe(12);
-		expect(row.satisfaction_score).toBe(0.155);
+		expect(row.subscribers_gained).toBe(5);
+		expect(row.subscribers_lost).toBe(1);
+		expect(row.subscribers_net).toBeNull();
+		expect(row.satisfaction_score).toBeNull();
 
-		// Conflict update
 		record.views = 200;
 		record.likes = 15;
 		saveAnalyticsRecord(db, record);
@@ -223,6 +209,7 @@ describe("YouTube Analytics Seam", () => {
 			.get() as AnalyticsRow;
 		expect(updatedRow.views).toBe(200);
 		expect(updatedRow.likes).toBe(15);
+		expect(updatedRow.satisfaction_score).toBeNull();
 
 		db.close();
 	});


### PR DESCRIPTION
## Summary

Adds the YT3 side of `KAFKA2306/dancer#20` while preserving YT3 as the YouTube/channel-routing authority.

- imports a verified dancer `manifest.json` into the existing YT3 run state
- verifies selected video SHA-256, thumbnail provenance/size/format, compliance status and explicit destination profile before publish
- retains private staging and live channel-identity verification
- stores a private-upload checkpoint immediately after upload so failures in thumbnail/caption/schedule gates cannot cause duplicate `videos.insert` on retry
- verifies custom thumbnail for dancer runs fail-closed
- supports optional caption upload and waits for `serving`
- supports `status.publishAt` and verifies the scheduled private state
- requests the official OAuth scopes required for upload, caption, readonly identity and Analytics
- replaces invalid Analytics metric names with current official metrics
- removes the unapproved custom satisfaction score from ingestion and stores raw API metrics/queries instead
- uses explicit calendar windows (`published_day`, `first_7d`) rather than labeling all-time results as 24h/7d
- verifies authorization/channel/video existence before Analytics refresh and deletes stale Analytics when the video no longer exists

## Related dancer issues

- KAFKA2306/dancer#21
- KAFKA2306/dancer#26
- KAFKA2306/dancer#28
- KAFKA2306/dancer#29
- KAFKA2306/dancer#30

## Primary sources

- videos.insert / publishAt / containsSyntheticMedia: https://developers.google.com/youtube/v3/docs/videos/insert
- captions.insert scope and upload contract: https://developers.google.com/youtube/v3/docs/captions/insert
- YouTube Analytics metrics: https://developers.google.com/youtube/analytics/metrics
- Analytics reports.query: https://developers.google.com/youtube/analytics/reference/reports/query
- YouTube developer policies: https://developers.google.com/youtube/terms/developer-policies
- derived metrics/data policy: https://developers.google.com/youtube/terms/derived-metrics-policy

## Verification

The existing YT3 CI runs TypeScript typecheck, Biome, publish-routing/no-fallback audits and Bun tests. New tests cover private staging/synthetic disclosure, scheduled-publish validation and bounded Analytics date windows.