### PR TITLE
Enforce 30-day Analytics authorization refresh boundary

### DIFF
--- a/src/scripts/refresh_youtube_analytics.ts
+++ b/src/scripts/refresh_youtube_analytics.ts
@@ -1,0 +1,70 @@
+import { Database } from "bun:sqlite";
+import path from "node:path";
+import fs from "fs-extra";
+import { discoverVideos } from "./ingest_youtube_analytics.js";
+
+const DEFAULT_DB_FILE = "db/evolution.db";
+const MAX_AUTHORIZATION_AGE_DAYS = 30;
+
+export function purgeAnalyticsPastAuthorizationDeadline(
+	db: Database,
+	baseDir = process.cwd(),
+	now = new Date(),
+	maxAgeDays = MAX_AUTHORIZATION_AGE_DAYS,
+): number {
+	const cutoff = new Date(now.getTime() - maxAgeDays * 86_400_000)
+		.toISOString()
+		.replace("T", " ")
+		.replace("Z", "");
+	const stale = db
+		.query(
+			"SELECT video_id, age_window FROM youtube_analytics WHERE recorded_at < ?",
+		)
+		.all(cutoff) as Array<{ video_id: string; age_window: string }>;
+	if (stale.length === 0) return 0;
+
+	const runByVideoId = new Map(
+		discoverVideos(baseDir).map((video) => [video.videoId, video.runDir]),
+	);
+	const remove = db.prepare(
+		"DELETE FROM youtube_analytics WHERE video_id = ? AND age_window = ?",
+	);
+	for (const row of stale) {
+		remove.run(row.video_id, row.age_window);
+		const runDir = runByVideoId.get(row.video_id);
+		if (runDir) {
+			fs.removeSync(path.join(runDir, "analytics", `${row.age_window}.json`));
+		}
+	}
+	return stale.length;
+}
+
+async function main() {
+	const db = new Database(DEFAULT_DB_FILE);
+	try {
+		const purged = purgeAnalyticsPastAuthorizationDeadline(db);
+		if (purged > 0) {
+			console.log(
+				`Purged ${purged} analytics record(s) older than ${MAX_AUTHORIZATION_AGE_DAYS} days before authorization refresh.`,
+			);
+		}
+	} finally {
+		db.close();
+	}
+
+	const child = Bun.spawn(
+		["bun", "src/scripts/ingest_youtube_analytics.ts"],
+		{ cwd: process.cwd(), stdout: "inherit", stderr: "inherit" },
+	);
+	const exitCode = await child.exited;
+	if (exitCode !== 0) {
+		throw new Error(`YouTube Analytics refresh failed with exit code ${exitCode}`);
+	}
+}
+
+if (import.meta.main) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exit(1);
+	});
+}

--- a/src/scripts/refresh_youtube_analytics.ts
+++ b/src/scripts/refresh_youtube_analytics.ts
@@ -52,13 +52,16 @@ async function main() {
 		db.close();
 	}
 
-	const child = Bun.spawn(
-		["bun", "src/scripts/ingest_youtube_analytics.ts"],
-		{ cwd: process.cwd(), stdout: "inherit", stderr: "inherit" },
-	);
+	const child = Bun.spawn(["bun", "src/scripts/ingest_youtube_analytics.ts"], {
+		cwd: process.cwd(),
+		stdout: "inherit",
+		stderr: "inherit",
+	});
 	const exitCode = await child.exited;
 	if (exitCode !== 0) {
-		throw new Error(`YouTube Analytics refresh failed with exit code ${exitCode}`);
+		throw new Error(
+			`YouTube Analytics refresh failed with exit code ${exitCode}`,
+		);
 	}
 }
 

--- a/tests/youtube_analytics_policy.test.ts
+++ b/tests/youtube_analytics_policy.test.ts
@@ -1,0 +1,85 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "node:path";
+import fs from "fs-extra";
+import { purgeAnalyticsPastAuthorizationDeadline } from "../src/scripts/refresh_youtube_analytics.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) fs.removeSync(root);
+});
+
+function createAnalyticsTable(db: Database) {
+	db.exec(`
+		CREATE TABLE youtube_analytics (
+			video_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			age_window TEXT NOT NULL,
+			views INTEGER NOT NULL,
+			recorded_at TEXT NOT NULL,
+			PRIMARY KEY (video_id, age_window)
+		)
+	`);
+}
+
+describe("YouTube Analytics 30-day storage boundary", () => {
+	test("purges stale rows and matching raw evidence while retaining fresh rows", () => {
+		const root = path.join(
+			process.cwd(),
+			"tests",
+			`.tmp-analytics-policy-${Date.now()}`,
+		);
+		tempRoots.push(root);
+		const runDir = path.join(root, "runs", "byosan_money", "dancer-test");
+		fs.ensureDirSync(path.join(runDir, "publish"));
+		fs.ensureDirSync(path.join(runDir, "analytics"));
+		fs.writeJsonSync(path.join(runDir, "publish", "receipt.json"), {
+			youtube: {
+				video_id: "video-stale",
+				channel_id: "channel-1",
+				published_at: "2026-01-01T00:00:00Z",
+			},
+		});
+		fs.writeJsonSync(path.join(runDir, "analytics", "first_7d.json"), {
+			retrieved_at: "2026-06-01T00:00:00Z",
+		});
+
+		const db = new Database(":memory:");
+		createAnalyticsTable(db);
+		db.prepare(
+			"INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)",
+		).run(
+			"video-stale",
+			"channel-1",
+			"first_7d",
+			100,
+			"2026-06-01 00:00:00",
+		);
+		db.prepare(
+			"INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)",
+		).run(
+			"video-fresh",
+			"channel-1",
+			"first_7d",
+			200,
+			"2026-08-10 00:00:00",
+		);
+
+		const purged = purgeAnalyticsPastAuthorizationDeadline(
+			db,
+			root,
+			new Date("2026-08-20T00:00:00Z"),
+		);
+		expect(purged).toBe(1);
+		expect(
+			db
+				.query("SELECT count(*) AS n FROM youtube_analytics")
+				.get() as { n: number },
+		).toEqual({ n: 1 });
+		expect(
+			fs.existsSync(path.join(runDir, "analytics", "first_7d.json")),
+		).toBe(false);
+		db.close();
+	});
+});

--- a/tests/youtube_analytics_policy.test.ts
+++ b/tests/youtube_analytics_policy.test.ts
@@ -47,18 +47,14 @@ describe("YouTube Analytics 30-day storage boundary", () => {
 
 		const db = new Database(":memory:");
 		createAnalyticsTable(db);
-		db.prepare(
-			"INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)",
-		).run(
+		db.prepare("INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)").run(
 			"video-stale",
 			"channel-1",
 			"first_7d",
 			100,
 			"2026-06-01 00:00:00",
 		);
-		db.prepare(
-			"INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)",
-		).run(
+		db.prepare("INSERT INTO youtube_analytics VALUES (?, ?, ?, ?, ?)").run(
 			"video-fresh",
 			"channel-1",
 			"first_7d",
@@ -73,13 +69,13 @@ describe("YouTube Analytics 30-day storage boundary", () => {
 		);
 		expect(purged).toBe(1);
 		expect(
-			db
-				.query("SELECT count(*) AS n FROM youtube_analytics")
-				.get() as { n: number },
+			db.query("SELECT count(*) AS n FROM youtube_analytics").get() as {
+				n: number;
+			},
 		).toEqual({ n: 1 });
-		expect(
-			fs.existsSync(path.join(runDir, "analytics", "first_7d.json")),
-		).toBe(false);
+		expect(fs.existsSync(path.join(runDir, "analytics", "first_7d.json"))).toBe(
+			false,
+		);
 		db.close();
 	});
 });


### PR DESCRIPTION
## Summary

Completes the storage/authorization boundary for `KAFKA2306/dancer#28`.

YouTube's current Developer Policies allow authorized Analytics/statistical data to be retained longer than 30 days only if authorization and video existence are revalidated at least every 30 days. The existing ingestion already revalidates channel authorization and video existence on every successful refresh. This adds the conservative missing side: before refresh, rows and raw evidence older than 30 days are purged, so a failed refresh cannot leave unverified statistics retained beyond the authorization deadline.

- adds `src/scripts/refresh_youtube_analytics.ts`
- purges DB rows older than 30 days before calling the existing authorized ingestion
- removes the matching raw `analytics/<window>.json` evidence
- adds a regression test proving stale rows/evidence are removed while fresh data remains
- does not add or store derived performance scores

Primary policy: https://developers.google.com/youtube/terms/developer-policies

Related: KAFKA2306/dancer#28