### PR TITLE
Finalize dancer import gates and Analytics entrypoint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
 
   notebooklm:
     desc: "Run NotebookLM workflow"
-    cmds: ["bun --env-file=config/.env src/notebooklm_workflow.ts"]
+    cmds: ["bun --env-file=config/.env src/notebooklm_workflow.ts {{.CLI_ARGS}}"]
 
   publish:nlm:
     desc: "Batch publish existing runs-nlm videos"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
 
   notebooklm:
     desc: "Run NotebookLM workflow"
-    cmds: ["bun --env-file=config/.env src/notebooklm_workflow.ts {{.CLI_ARGS}}"]
+    cmds: ["bun --env-file=config/.env src/notebooklm_workflow.ts"]
 
   publish:nlm:
     desc: "Batch publish existing runs-nlm videos"
@@ -91,6 +91,10 @@ tasks:
   publish:visibility-audit:
     desc: "Audit published video visibility"
     cmds: ["bun src/scripts/public_visibility_audit.ts"]
+
+  analytics:refresh:
+    desc: "Refresh authorized YouTube Analytics and purge data past the 30-day authorization boundary"
+    cmds: ["bun src/scripts/refresh_youtube_analytics.ts"]
 
   db:backfill:
     desc: "Backfill historic runs into the Evolution Database"

--- a/src/scripts/import_dancer_artifact.ts
+++ b/src/scripts/import_dancer_artifact.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { getYouTubeProfile } from "../domain/youtube_profiles.js";
 import { type AgentState, AssetStore } from "../io/core.js";
 
-type DancerManifest = {
+export type DancerManifest = {
 	schema_version: number;
 	run_id: string;
 	selected?: { video_path?: string; video_sha256?: string };
@@ -21,10 +21,28 @@ type DancerManifest = {
 		thumbnail_title?: string;
 		path?: string;
 	};
+	presentation_audit?: { passed?: boolean };
 	caption_path?: string | null;
 	publish_at?: string | null;
 	compliance?: { passed?: boolean; contains_synthetic_media?: boolean };
 };
+
+export function validateDancerManifest(manifest: DancerManifest): void {
+	if (manifest.schema_version !== 1)
+		throw new Error(
+			`Unsupported dancer manifest schema: ${manifest.schema_version}`,
+		);
+	if (!manifest.run_id || !/^dancer-[a-f0-9]{20}$/.test(manifest.run_id))
+		throw new Error(`Invalid dancer run id: ${manifest.run_id || "missing"}`);
+	if (manifest.presentation_audit?.passed !== true)
+		throw new Error(
+			"Dancer manifest did not pass the metadata/thumbnail contradiction gate",
+		);
+	if (manifest.compliance?.passed !== true)
+		throw new Error(
+			"Dancer manifest did not pass the rights/provenance compliance gate",
+		);
+}
 
 function sha256(filePath: string): string {
 	const hash = crypto.createHash("sha256");
@@ -52,16 +70,8 @@ function main() {
 	const profile = getYouTubeProfile(profileArg);
 	const manifestPath = requireFile(manifestArg, "manifest path");
 	const manifest = fs.readJsonSync(manifestPath) as DancerManifest;
-	if (manifest.schema_version !== 1)
-		throw new Error(
-			`Unsupported dancer manifest schema: ${manifest.schema_version}`,
-		);
-	if (!manifest.run_id || !/^dancer-[a-f0-9]{20}$/.test(manifest.run_id))
-		throw new Error(`Invalid dancer run id: ${manifest.run_id || "missing"}`);
-	if (manifest.compliance?.passed !== true)
-		throw new Error(
-			"Dancer manifest did not pass the rights/provenance compliance gate",
-		);
+	validateDancerManifest(manifest);
+
 	const videoPath = requireFile(
 		manifest.selected?.video_path,
 		"selected video",
@@ -142,9 +152,11 @@ function main() {
 	);
 }
 
-try {
-	main();
-} catch (error) {
-	console.error(error instanceof Error ? error.message : error);
-	process.exit(1);
+if (import.meta.main) {
+	try {
+		main();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : error);
+		process.exit(1);
+	}
 }

--- a/tests/dancer_import_contract.test.ts
+++ b/tests/dancer_import_contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type DancerManifest,
+	validateDancerManifest,
+} from "../src/scripts/import_dancer_artifact.js";
+
+function validManifest(): DancerManifest {
+	return {
+		schema_version: 1,
+		run_id: "dancer-0123456789abcdef0123",
+		presentation_audit: { passed: true },
+		compliance: { passed: true, contains_synthetic_media: false },
+	};
+}
+
+describe("dancer manifest import gate", () => {
+	test("accepts a manifest only after presentation and compliance audits pass", () => {
+		expect(() => validateDancerManifest(validManifest())).not.toThrow();
+	});
+
+	test("rejects metadata/thumbnail contradictions before any publication work", () => {
+		const manifest = validManifest();
+		manifest.presentation_audit = { passed: false };
+		expect(() => validateDancerManifest(manifest)).toThrow(
+			"metadata/thumbnail contradiction gate",
+		);
+	});
+
+	test("rejects rights/provenance failure before any publication work", () => {
+		const manifest = validManifest();
+		manifest.compliance = { passed: false };
+		expect(() => validateDancerManifest(manifest)).toThrow(
+			"rights/provenance compliance gate",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Completes the remaining executable/audit boundaries for KAFKA2306/dancer#21, #27, and #28.

- adds canonical `task analytics:refresh`
- delegates to the merged 30-day purge + authorized Analytics refresh path
- requires `presentation_audit.passed` as well as rights/provenance `compliance.passed` before a dancer manifest can be imported for publication
- exports the pure dancer-manifest gate and tests both rejection paths offline
- preserves the rest of Taskfile unchanged

Related merged work: #20, #21.