### PR TITLE
Separate PR merge and product release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
+  merge-gate:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,5 +21,5 @@ jobs:
     - name: Install dependencies from lockfile
       run: bun ci
 
-    - name: Canonical quality gate
-      run: bun run check
+    - name: PR merge gate
+      run: bun run check:merge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ repos:
   - repo: local
     hooks:
       - id: yt3-fast-check
-        name: YT3 fast deterministic quality gate
-        entry: bun run check:fast
+        name: YT3 fast PR merge gate
+        entry: bun run check:merge:fast
         language: system
         pass_filenames: false
         stages: [pre-commit, pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ For non-trivial work, identify:
 ```bash
 task --list
 task setup
-task check:fast
-task check
+task check:merge:fast
+task check:merge
 ```
 
 Use narrower checks when relevant:
@@ -88,7 +88,8 @@ task harness:doctor:quick
 task harness:doctor
 task audit:today
 task audit:publish-routing
-task audit:no-fallback
+task audit:no-fallback:source
+task audit:no-fallback:runtime
 task audit:repo-contract
 task daily:last3
 task daily:guarantee-status
@@ -96,7 +97,23 @@ task daily:guarantee-status
 
 Internal package scripts and `src/scripts/*` files support Taskfile and CI; they are not competing human-facing command surfaces.
 
-## 8. Builder and auditor separation
+## 8. Merge acceptance and product release are independent
+
+Never use one gate as evidence for the other.
+
+### PR merge gate
+
+`task check:merge` decides whether the repository revision is acceptable to merge. It is restricted to repository/source state and deterministic tests. It must not require production credentials, a concrete `RUN_ID`, current YouTube state, or historical runtime cleanup receipts.
+
+A green CI run means **merge criteria passed for that commit**. It does not mean a video is ready or authorized for publication.
+
+### Product release gate
+
+`task release:check PROFILE=<profile> -- <run-id> [video-path]` decides whether one concrete run/artifact is locally ready to cross the publication boundary. It evaluates run/profile alignment, artifact identity, factual-integrity evidence, fallback prohibition, and canonical publication conflict state.
+
+A passing release preflight does not mean publication occurred. Remote channel identity and post-publication visibility still require separate evidence.
+
+## 9. Builder and auditor separation
 
 Treat implementation and acceptance as separate roles even when one agent performs both sequentially.
 
@@ -104,7 +121,7 @@ The builder may inspect, modify, test, and open/update the canonical PR. The aud
 
 Implementation intent is not acceptance evidence.
 
-## 9. Fail closed
+## 10. Fail closed
 
 Prefer attributable failure over false success.
 
@@ -116,7 +133,7 @@ Prefer attributable failure over false success.
 
 Repeated failures should produce a durable harness improvement: validation, schema, routing, retry policy, eval, observability, or implementation change.
 
-## 10. Channel isolation
+## 11. Channel isolation
 
 Never mix these profiles:
 
@@ -128,17 +145,17 @@ Never mix these profiles:
 
 For Humanity, the expected channel handle is `@humanity_observatory`.
 
-Before publication, verify profile, environment, bucket, authenticated channel, artifact identity, intended visibility, and required audit evidence.
+Before publication, verify profile, environment, bucket, authenticated channel, artifact identity, intended visibility, and required audit evidence. Static profile routing is a merge-time repository invariant; concrete run/channel identity is a release-time invariant.
 
-## 11. Publishing is an irreversible side effect
+## 12. Publishing is an irreversible side effect
 
-Implementation and local production do not authorize publication.
+Implementation and local production do not authorize publication. A merged PR does not authorize publication either.
 
-Publish only when the user request or active canonical contract explicitly requires it. Use the Taskfile publication path, capture the remote receipt, and read back remote identity/visibility when possible.
+Publish only when the user request or active canonical contract explicitly requires it. Use the Taskfile publication path. The canonical YouTube publisher executes the product release gate before OAuth/channel verification and remote publication work.
 
-Without a remote receipt, publication is not VERIFIED.
+Capture the remote receipt and read back remote identity/visibility when possible. Without a remote receipt, publication is not VERIFIED.
 
-## 12. Minimal and reversible changes
+## 13. Minimal and reversible changes
 
 Prefer the smallest change that satisfies the contract.
 
@@ -151,28 +168,34 @@ Prefer the smallest change that satisfies the contract.
 
 For destructive or external changes, verify the target before and after the action.
 
-## 13. Investigation before implementation
+## 14. Investigation before implementation
 
 Before editing, inspect the relevant repository state, implementation/configuration, tests/audits, and CI definitions. Inspect primary external sources when the task depends on current third-party behavior. Identify authoritative state stores and generated projections before changing either.
 
 Do not design from filenames, stale comments, screenshots, memory, or issue prose when inspectable evidence exists.
 
-## 14. Validation ladder
+## 15. Validation ladder
 
-Use the cheapest deterministic check that can falsify the change, then escalate:
+For repository changes, use the cheapest deterministic check that can falsify the change, then escalate:
 
 1. targeted unit/schema/contract test
 2. targeted domain audit
-3. `task check:fast`
-4. `task check`
+3. `task check:merge:fast`
+4. `task check:merge`
 5. `task harness:doctor:quick` when relevant
 6. full domain/harness audit when relevant
 7. CI on the exact PR head SHA
-8. external postcondition/receipt for external state changes
 
-Do not run expensive production merely because it exists.
+For a requested product release, start a separate release ladder only after the repository revision is known:
 
-## 15. Git and PR protocol
+1. `task release:check PROFILE=<profile> -- <run-id> [video-path]`
+2. authenticated channel verification
+3. remote publication action when explicitly authorized
+4. remote receipt/read-back/visibility evidence
+
+Do not run production release checks merely to prove a PR is mergeable, and do not treat a merge-gate PASS as product release evidence.
+
+## 16. Git and PR protocol
 
 For repository changes:
 
@@ -184,38 +207,41 @@ For repository changes:
 6. open or update one canonical PR;
 7. inspect CI on the exact head SHA;
 8. diagnose failed jobs rather than retrying blindly;
-9. merge only when acceptance criteria and repository policy allow it;
+9. merge only when merge acceptance criteria and repository policy allow it;
 10. verify the merged base and clean up the workline when possible.
+
+Product release readiness is not a condition for merging a code PR unless the PR contract explicitly changes a production artifact and requires that external postcondition.
 
 If a host-side safety check rejects a write, re-fetch state and retry the same canonical action once. Do not create a duplicate branch/PR as a workaround.
 
-## 16. Cleanup
+## 17. Cleanup
 
 Before final reporting, inspect for temporary files, debug output, staging chunks, abandoned generated intermediates, one-time workflows/scripts, superseded PRs, and stale task/document references.
 
 If unfinished work must remain, keep one canonical workline with the blocker and exact next action recorded.
 
-## 17. Secrets and private data
+## 18. Secrets and private data
 
 Never expose secrets, OAuth credentials, private tokens, local absolute paths, or private intermediate metadata in public artifacts. Do not copy production credentials or account identifiers into tests, docs, prompts, or screenshots.
 
-## 18. Documentation discipline
+## 19. Documentation discipline
 
 Documentation describes current behavior, not intended future behavior.
 
 - human onboarding: `README.md`
 - agent execution rules: `AGENTS.md`
+- gate ownership: `docs/QUALITY_GATES.md`
 - standards: `docs/standard/`
 - architectural decisions: `docs/adr/`
 - reusable agent skills: skill files
 
 `task audit:repo-contract` protects the maintained entry-point documentation from drifting toward missing files or tasks.
 
-## 19. No external-agent dependency
+## 20. No external-agent dependency
 
 Do not make ChatGPT Work, Codex, or another agent workspace a required execution step. The canonical loop must remain reproducible from repository state, declared tools, Taskfile tasks, tests/audits, CI, and explicit external-service receipts.
 
-## 20. Final report contract
+## 21. Final report contract
 
 Report only verified state relevant to the task:
 
@@ -223,10 +249,11 @@ Report only verified state relevant to the task:
 - what changed
 - deterministic checks executed and their result
 - commit/PR/merge state
-- external receipt if external state changed
+- product release gate result only when a concrete run was actually checked
+- external receipt only if external state changed
 - cleanup performed
 - blocker and exact next action if unfinished
 
-## 21. Stopping rule
+## 22. Stopping rule
 
 Stop when the requested outcome exists, acceptance evidence belongs to the current final state, required CI/external postconditions are verified, task-created residue is removed, and no known blocker remains. Further work is then scope expansion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,78 +1,61 @@
 # YT3 Agent Operating Contract
 
-This file defines how autonomous agents inspect, change, verify, and report work in this repository. `README.md` is human orientation; `Taskfile.yml` is the canonical executable interface.
+`AGENTS.md` defines repository-wide rules for autonomous work. `README.md` is human orientation; `Taskfile.yml` is the canonical executable interface.
 
-## 1. Mission
+The objective is not to produce plausible changes. It is to leave YT3 in a verified state with the smallest sufficient diff, one canonical workline, and evidence that belongs to the final state.
 
-Operate YT3 as a reproducible, evidence-backed media production system.
+## 1. Evidence decides current state
 
-```text
-request
-  -> inspect current state
-  -> select one canonical workline
-  -> implement the smallest sufficient change
-  -> validate deterministically
-  -> inspect evidence
-  -> improve the harness when failures recur
-  -> stop at a fixed point
-```
+Use the most direct current evidence available. When sources conflict, prefer:
 
-Code written is not completion. Completion requires evidence that the requested outcome exists in the current repository/runtime state.
-
-## 2. Source-of-truth precedence
-
-When sources disagree, use this order:
-
-1. current tool/runtime observations
+1. current runtime/tool observations
 2. current repository code and configuration
-3. `Taskfile.yml` executable entry points
+3. `Taskfile.yml` and executable checks
 4. deterministic tests, audits, receipts, and CI
 5. maintained ADRs and standards under `docs/`
 6. `GEMINI.md`
-7. README, local agent notes, issues, and historical prose
+7. README, issues, local agent notes, and historical prose
 8. inference
 
-Never let stale prose override current executable reality. Before using a documented command, verify that its Taskfile task still exists.
+Do not let stale prose override executable reality. Verify a documented task or path before relying on it.
 
-## 3. Claim provenance
+For material claims, distinguish:
 
-Material claims must be classified as:
-
-- **VERIFIED** — directly observed with a tool, file read, deterministic artifact, API response, or CI result
-- **OBSERVED** — explicit user or authoritative external input
-- **INFERRED** — a conclusion derived from evidence and labeled as inference
+- **VERIFIED** — directly observed from a tool, file, deterministic artifact, API response, receipt, or CI result
+- **OBSERVED** — explicitly supplied by the user or an authoritative external source
+- **INFERRED** — derived from evidence and identified as inference
 - **UNVERIFIED** — not inspected yet
 - **FABRICATED** — forbidden
 
-Do not convert “not checked” into “absent”, or “command returned” into “outcome succeeded”. Never report PASS for a verifier that was not executed.
+“Not checked” is not “absent”. A command returning is not proof that its intended postcondition exists. Never report a verifier as passing unless it actually ran against the state being reported.
 
-## 4. Antigravity runtime evidence
+## 2. Define the contract before non-trivial changes
 
-When Antigravity is relevant, `agy` is the canonical runtime identifier. Before claiming it is absent or unavailable, inspect `which agy`, `agy --version`, `agy --help`, and `agy /usage`, then inspect Taskfile/systemd/tmux/shell/cron integration as applicable. Absence of a `.agy` path is not evidence that the runtime is absent.
+Identify five things before editing:
 
-## 5. Canonical workline
+- **Contract** — what must change and what must remain unchanged
+- **Outcome** — the observable state required afterward
+- **Acceptance** — deterministic checks that can falsify the change
+- **Evidence** — files, commands, CI runs, receipts, or external read-backs that prove the outcome
+- **Stop condition** — the fixed point after which additional work is scope expansion
+
+Prefer the smallest reversible change that satisfies this contract.
+
+## 3. Keep one canonical workline
 
 Before creating work:
 
-1. continue an existing canonical PR/branch for the requested outcome;
+1. continue the existing PR/branch for the requested outcome;
 2. otherwise continue the relevant unresolved Issue;
 3. only then create one new branch and one PR.
 
-Do not create parallel implementation paths or competing state stores for the same outcome. Superseded work should be consolidated and removed when safe.
+Do not create parallel implementation paths, duplicate PRs, or competing state stores for the same outcome. Consolidate superseded work when safe.
 
-## 6. Contract before change
+If a host-side safety check rejects a write, re-fetch current state and retry the same canonical action once. Do not bypass the rejection by creating another branch or PR.
 
-For non-trivial work, identify:
+## 4. Use Taskfile as the operator interface
 
-- **Contract** — what must change and what must remain unchanged
-- **Outcome** — observable state required afterward
-- **Acceptance criteria** — deterministic checks that prove it
-- **Evidence** — files, commands, CI runs, receipts, or external state
-- **Stopping condition** — the fixed point after which more work is scope expansion
-
-## 7. Repository entry point
-
-`Taskfile.yml` is the operator interface.
+Start with:
 
 ```bash
 task --list
@@ -81,61 +64,55 @@ task check:merge:fast
 task check:merge
 ```
 
-Use narrower checks when relevant:
+Relevant narrower checks include:
 
 ```bash
-task harness:doctor:quick
-task harness:doctor
-task audit:today
+task audit:repo-contract
 task audit:publish-routing
 task audit:no-fallback:source
 task audit:no-fallback:runtime
-task audit:repo-contract
+task harness:doctor:quick
+task harness:doctor
+task audit:today
 task daily:last3
 task daily:guarantee-status
 ```
 
-Internal package scripts and `src/scripts/*` files support Taskfile and CI; they are not competing human-facing command surfaces.
+Internal package scripts and `src/scripts/*` support Taskfile and CI. They are not a second human-facing command surface unless the repository explicitly makes them one.
 
-## 8. Merge acceptance and product release are independent
+## 5. PR merge and product release are separate gates
 
 Never use one gate as evidence for the other.
 
-### PR merge gate
+### Merge gate
 
-`task check:merge` decides whether the repository revision is acceptable to merge. It is restricted to repository/source state and deterministic tests. It must not require production credentials, a concrete `RUN_ID`, current YouTube state, or historical runtime cleanup receipts.
+`task check:merge` decides whether a repository revision is acceptable to merge. It is limited to repository/source invariants and deterministic tests. It must not depend on production credentials, a concrete `RUN_ID`, current YouTube state, or historical runtime cleanup receipts.
 
-A green CI run means **merge criteria passed for that commit**. It does not mean a video is ready or authorized for publication.
+A green CI run proves only that merge criteria passed for that commit.
 
 ### Product release gate
 
-`task release:check PROFILE=<profile> -- <run-id> [video-path]` decides whether one concrete run/artifact is locally ready to cross the publication boundary. It evaluates run/profile alignment, artifact identity, factual-integrity evidence, fallback prohibition, and canonical publication conflict state.
+`task release:check PROFILE=<profile> -- <run-id> [video-path]` evaluates one concrete run/artifact before it may cross the publication boundary. It checks run/profile alignment, artifact identity, factual-integrity evidence, fallback prohibition, and publication-conflict state.
 
-A passing release preflight does not mean publication occurred. Remote channel identity and post-publication visibility still require separate evidence.
+A passing release check does not prove publication occurred. Remote channel identity, publication receipt, and final visibility require separate evidence.
 
-## 9. Builder and auditor separation
+Do not run product-release checks merely to prove a code PR is mergeable. Do not treat a merge-gate PASS as release evidence.
 
-Treat implementation and acceptance as separate roles even when one agent performs both sequentially.
-
-The builder may inspect, modify, test, and open/update the canonical PR. The auditor independently verifies that the requested outcome exists, evidence belongs to the current head state, required checks pass, unrelated channel state was not contaminated, and cleanup is complete.
-
-Implementation intent is not acceptance evidence.
-
-## 10. Fail closed
+## 6. Fail closed at real boundaries
 
 Prefer attributable failure over false success.
 
-- Do not hide errors with fallback output that resembles success.
-- Do not suppress verifier failures to keep a pipeline green.
-- Do not invent substitute data for missing required inputs.
-- Do not publish fallback media as the requested artifact.
-- Missing dependency, timeout, crash, missing receipt, or ambiguous profile blocks the corresponding criterion.
+- do not hide errors behind fallback output that resembles success
+- do not suppress verifier failures to keep pipelines green
+- do not invent substitute data for required missing inputs
+- do not publish fallback media as the requested artifact
+- missing dependencies, timeouts, crashes, missing receipts, or ambiguous profiles block only the criterion they prevent proving
 
-Repeated failures should produce a durable harness improvement: validation, schema, routing, retry policy, eval, observability, or implementation change.
+When a failure pattern repeats, improve the durable harness: validation, schema, routing, retry policy, eval, observability, or implementation. Do not accumulate ad-hoc recovery paths.
 
-## 11. Channel isolation
+## 7. Preserve channel and publication isolation
 
-Never mix these profiles:
+These profiles are distinct products:
 
 | profile | brand | bucket |
 |---|---|---|
@@ -145,38 +122,30 @@ Never mix these profiles:
 
 For Humanity, the expected channel handle is `@humanity_observatory`.
 
-Before publication, verify profile, environment, bucket, authenticated channel, artifact identity, intended visibility, and required audit evidence. Static profile routing is a merge-time repository invariant; concrete run/channel identity is a release-time invariant.
+Static routing is a merge-time repository invariant. Concrete run, artifact, authenticated channel, intended visibility, and publication evidence are release-time invariants.
 
-## 12. Publishing is an irreversible side effect
+Publishing is an irreversible external side effect. A code change, green CI, merged PR, produced video, or passing release preflight does not by itself authorize publication. Publish only when the active user request or canonical contract explicitly requires it, through the Taskfile publication path. Capture the remote receipt and read back remote identity/visibility when possible.
 
-Implementation and local production do not authorize publication. A merged PR does not authorize publication either.
+Without a remote receipt, publication is not VERIFIED.
 
-Publish only when the user request or active canonical contract explicitly requires it. Use the Taskfile publication path. The canonical YouTube publisher executes the product release gate before OAuth/channel verification and remote publication work.
+## 8. Change source, not projections
 
-Capture the remote receipt and read back remote identity/visibility when possible. Without a remote receipt, publication is not VERIFIED.
+Before editing, inspect the relevant implementation, configuration, tests/audits, CI definitions, and authoritative state stores. When current third-party behavior matters, inspect primary external evidence.
 
-## 13. Minimal and reversible changes
-
-Prefer the smallest change that satisfies the contract.
+Then:
 
 - preserve stable IDs and provenance unless replacement is required
-- avoid speculative abstractions
-- remove obsolete helpers introduced or exposed by the work
-- do not create a second configuration or state source
-- fix generators rather than hand-editing their generated output
-- do not change unrelated valid work
+- fix generators rather than hand-editing generated output
+- avoid speculative abstractions and duplicate configuration/state sources
+- remove obsolete helpers exposed by the change when safe
+- do not alter unrelated valid work
+- verify destructive or external targets before and after mutation
 
-For destructive or external changes, verify the target before and after the action.
+Do not design from filenames, screenshots, stale comments, memory, or issue prose when direct evidence is available.
 
-## 14. Investigation before implementation
+## 9. Validate from cheap to expensive
 
-Before editing, inspect the relevant repository state, implementation/configuration, tests/audits, and CI definitions. Inspect primary external sources when the task depends on current third-party behavior. Identify authoritative state stores and generated projections before changing either.
-
-Do not design from filenames, stale comments, screenshots, memory, or issue prose when inspectable evidence exists.
-
-## 15. Validation ladder
-
-For repository changes, use the cheapest deterministic check that can falsify the change, then escalate:
+For repository changes, escalate only as needed:
 
 1. targeted unit/schema/contract test
 2. targeted domain audit
@@ -186,74 +155,70 @@ For repository changes, use the cheapest deterministic check that can falsify th
 6. full domain/harness audit when relevant
 7. CI on the exact PR head SHA
 
-For a requested product release, start a separate release ladder only after the repository revision is known:
+For an explicitly requested product release, use a separate ladder after the repository revision is known:
 
 1. `task release:check PROFILE=<profile> -- <run-id> [video-path]`
 2. authenticated channel verification
-3. remote publication action when explicitly authorized
-4. remote receipt/read-back/visibility evidence
+3. remote publication action when authorized
+4. remote receipt/read-back/visibility verification
 
-Do not run production release checks merely to prove a PR is mergeable, and do not treat a merge-gate PASS as product release evidence.
+Implementation intent is not acceptance evidence. Treat builder and auditor as separate roles even when the same agent performs them sequentially.
 
-## 16. Git and PR protocol
+## 10. Git, CI, and cleanup
 
 For repository changes:
 
-1. start from the latest intended base;
-2. reuse the canonical branch if one exists;
-3. otherwise create one descriptive branch;
-4. keep the diff focused;
-5. include tests/audits for material behavior changes where practical;
-6. open or update one canonical PR;
-7. inspect CI on the exact head SHA;
-8. diagnose failed jobs rather than retrying blindly;
-9. merge only when merge acceptance criteria and repository policy allow it;
-10. verify the merged base and clean up the workline when possible.
+1. start from the latest intended base and canonical branch;
+2. keep the diff focused;
+3. add or update deterministic tests/audits for material behavior changes where practical;
+4. update the canonical PR rather than opening a competing one;
+5. inspect CI for the exact head SHA;
+6. diagnose failures rather than retrying blindly;
+7. merge only when merge acceptance criteria and repository policy allow it;
+8. after merge, verify the intended base state and remove task-created residue when possible.
 
-Product release readiness is not a condition for merging a code PR unless the PR contract explicitly changes a production artifact and requires that external postcondition.
+Before final reporting, inspect for temporary files, debug output, staging chunks, abandoned intermediates, one-time workflows/scripts, superseded worklines, and stale task/document references.
 
-If a host-side safety check rejects a write, re-fetch state and retry the same canonical action once. Do not create a duplicate branch/PR as a workaround.
+If unfinished work must remain, leave exactly one canonical workline with the blocker and next executable action recorded.
 
-## 17. Cleanup
-
-Before final reporting, inspect for temporary files, debug output, staging chunks, abandoned generated intermediates, one-time workflows/scripts, superseded PRs, and stale task/document references.
-
-If unfinished work must remain, keep one canonical workline with the blocker and exact next action recorded.
-
-## 18. Secrets and private data
-
-Never expose secrets, OAuth credentials, private tokens, local absolute paths, or private intermediate metadata in public artifacts. Do not copy production credentials or account identifiers into tests, docs, prompts, or screenshots.
-
-## 19. Documentation discipline
+## 11. Documentation and tooling boundaries
 
 Documentation describes current behavior, not intended future behavior.
 
 - human onboarding: `README.md`
-- agent execution rules: `AGENTS.md`
+- repository-wide agent rules: `AGENTS.md`
 - gate ownership: `docs/QUALITY_GATES.md`
 - standards: `docs/standard/`
 - architectural decisions: `docs/adr/`
-- reusable agent skills: skill files
+- reusable agent procedures: skill files
 
-`task audit:repo-contract` protects the maintained entry-point documentation from drifting toward missing files or tasks.
+`task audit:repo-contract` protects maintained entry-point documentation from drifting toward missing tasks or files.
 
-## 20. No external-agent dependency
+Agent-local accelerators such as prompt frameworks, editor integrations, LSPs, or external agent workspaces are optional implementation aids. They are not repository dependencies unless an executable repository workflow explicitly requires them. Do not add or restore a tool solely to satisfy one agent's preferred environment.
 
-Do not make ChatGPT Work, Codex, or another agent workspace a required execution step. The canonical loop must remain reproducible from repository state, declared tools, Taskfile tasks, tests/audits, CI, and explicit external-service receipts.
+Do not make ChatGPT Work, Codex, or another external agent workspace a required execution step. The canonical loop must remain reproducible from repository state, declared dependencies, Taskfile tasks, tests/audits, CI, and explicit external-service receipts.
 
-## 21. Final report contract
+## 12. Secrets, completion, and reporting
+
+Never expose secrets, OAuth credentials, private tokens, local absolute paths, or private intermediate metadata in public artifacts. Do not copy production credentials or account identifiers into tests, docs, prompts, or screenshots.
+
+Work is complete only when:
+
+- the requested outcome exists in the final state;
+- acceptance evidence belongs to that final state;
+- required CI and external postconditions are verified;
+- task-created residue is removed or intentionally retained on the canonical workline;
+- no known blocker remains.
 
 Report only verified state relevant to the task:
 
-- target repository/PR
+- repository and canonical PR/workline
 - what changed
-- deterministic checks executed and their result
+- deterministic checks actually executed and their results
 - commit/PR/merge state
-- product release gate result only when a concrete run was actually checked
-- external receipt only if external state changed
+- product release result only when a concrete run was checked
+- external receipt only when external state changed
 - cleanup performed
 - blocker and exact next action if unfinished
 
-## 22. Stopping rule
-
-Stop when the requested outcome exists, acceptance evidence belongs to the current final state, required CI/external postconditions are verified, task-created residue is removed, and no known blocker remains. Further work is then scope expansion.
+Stop at this fixed point. Further work is scope expansion.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ source / event
   -> script
   -> media production
   -> deterministic/editorial audit
-  -> factual-integrity gate
+  -> product release gate
   -> channel-routing verification
   -> private upload
   -> remote read-back
@@ -37,26 +37,41 @@ The core rules are:
 - **One operator surface.** `Taskfile.yml` owns executable entry points.
 - **Channel identity is a hard boundary.** 秒算マネー, 夜話アーカイブ, and 人類観測所 must not be mixed.
 - **State is for resumption; evidence is for proof.** Generated artifacts and attestations do not become competing workflow states.
+- **Merge and release are different decisions.** Repository readiness does not imply that any concrete product run is releasable.
 - **Publication is a separate side effect.** A rendered file is not a YouTube receipt, and a receipt is not remote visibility verification.
 
-## Setup and quality gates
+## Setup and PR merge gate
 
-Install the exact dependency graph committed in `bun.lock`, then run the canonical quality gate:
+Install the exact dependency graph committed in `bun.lock`, then run the explicit PR merge gate:
 
 ```bash
 task setup
-task check
+task check:merge
 ```
 
 For a faster deterministic preflight:
 
 ```bash
-task check:fast
+task check:merge:fast
 ```
 
-`check:fast` includes lint, typecheck, the repository-contract audit, publish-routing audit, and no-fallback audit. The repository-contract audit verifies that local executables referenced by Taskfile/package scripts exist and that the maintained entry-point documentation does not point at missing tasks or files.
+The merge gate checks repository/source state only: lint, types, repository contract, static publish routing, source-level no-fallback policy, and tests. It deliberately does **not** depend on production OAuth credentials, a specific `RUN_ID`, historical runtime receipts, or current YouTube state.
 
-Quality-gate ownership is documented in [docs/QUALITY_GATES.md](docs/QUALITY_GATES.md).
+`task check` and `task check:fast` remain compatibility aliases. Quality-gate ownership is documented in [docs/QUALITY_GATES.md](docs/QUALITY_GATES.md).
+
+## Product release gate
+
+A concrete run is checked separately before publication:
+
+```bash
+task release:check PROFILE=byosan -- <run-id> [video-path]
+task release:check PROFILE=yawa -- <run-id> [video-path]
+task release:check PROFILE=humanity -- <run-id> [video-path]
+```
+
+The product release gate verifies the selected profile/bucket, canonical run state, artifact existence and SHA-256 identity, no-fallback metadata, publication-state conflicts, and factual-integrity evidence when the configured visibility is non-private.
+
+Passing `release:check` does not publish anything. The canonical `publish` path runs the same product release gate before OAuth/channel verification or any YouTube publication step.
 
 ## Production
 
@@ -97,7 +112,7 @@ task publish PROFILE=yawa -- <run-id> [video-path]
 task publish PROFILE=humanity -- <run-id> [video-path]
 ```
 
-Unknown profiles fail closed. Before upload, YT3 verifies the intended profile against the authenticated YouTube channel. If a prior upload intent has uncertain remote commit state, the publisher stops rather than issuing another upload blindly.
+Unknown profiles fail closed. Before upload, YT3 executes the product release gate and then verifies the intended profile against the authenticated YouTube channel. If a prior upload intent has uncertain remote commit state, the publisher stops rather than issuing another upload blindly.
 
 ## Publication state
 
@@ -107,7 +122,7 @@ Do not compress these stages into one `done` flag:
 SCRIPT_DONE
 MEDIA_GENERATED
 AUDIT_PASSED
-FACTUAL_INTEGRITY_PASS
+PRODUCT_RELEASE_GATE_PASS
 ROUTING_VERIFIED
 PRIVATE_UPLOADED
 REMOTE_VERIFIED
@@ -115,7 +130,19 @@ VISIBILITY_APPLIED
 VISIBILITY_VERIFIED
 ```
 
-`runs/<domain>/<run>/publish/state.json` is the canonical publication state. Thumbnail, caption, visibility attestations, and `receipt.json` are evidence attached to that state rather than independent state machines.
+`runs/<domain>/<run>/publish/state.json` is the canonical publication state. Thumbnail, caption, factual-integrity, visibility attestations, and `receipt.json` are evidence attached to that state rather than independent state machines.
+
+## No-fallback scopes
+
+Source policy and runtime cleanup are separate concerns:
+
+```bash
+task audit:no-fallback:source
+task audit:no-fallback:runtime
+task audit:no-fallback
+```
+
+Only the source scope belongs to the PR merge gate. Historical runtime deletion evidence remains an operational audit and cannot block an unrelated code change from merging.
 
 ## Evidence layout
 
@@ -123,10 +150,10 @@ VISIBILITY_VERIFIED
 runs/<domain>/<run>/state.json             production state
 runs/<domain>/<run>/audit/                 audit results and raw evidence
 runs/<domain>/<run>/publish/state.json     canonical publication state
-runs/<domain>/<run>/publish/*.json         publication attestations and receipt
+runs/<domain>/<run>/publish/*.json         release/publication attestations and receipt
 runs/<domain>/<run>/run_evidence.json      cross-stage run evidence
-db/                                         cross-run evolution/audit data
-docs/                                       maintained standards and ADRs
+db/                                        cross-run evolution/audit data
+docs/                                      maintained standards and ADRs
 ```
 
 The system audit protocol is [docs/standard/system-audit-protocol.md](docs/standard/system-audit-protocol.md). Humanity Observatory has a separate domain standard at [docs/standard/humanity-observatory-audit-standard.md](docs/standard/humanity-observatory-audit-standard.md).
@@ -143,9 +170,10 @@ task byosan:daily
 task pulse:auto
 ```
 
-Publication:
+Release and publication:
 
 ```bash
+task release:check PROFILE=byosan -- <run-id>
 task publish:byosan -- <run-id>
 task publish:yawa -- <run-id>
 task publish:humanity -- <run-id>
@@ -159,6 +187,8 @@ Audit and status:
 task audit:today
 task audit:publish-routing
 task audit:byosan-money
+task audit:no-fallback:source
+task audit:no-fallback:runtime
 task audit:no-fallback
 task audit:repo-contract
 task publish:visibility-audit
@@ -181,7 +211,7 @@ Local service availability is environment-dependent; documentation is not eviden
 ## Repository map
 
 ```text
-src/          production, audit, publish, and workflow implementation
+src/          production, audit, release, publish, and workflow implementation
 config/       channel, environment, and domain configuration
 runs/         runtime state and evidence
 audits/       repository-level verification evidence
@@ -197,13 +227,15 @@ bun.lock      reproducible dependency graph
 
 ## Completion boundary
 
-YT3 is complete only to the highest stage for which current evidence exists. A render does not imply publication, and an upload ID does not imply requested visibility.
+A merged PR proves repository acceptance only. A passed product release gate proves local release readiness only. Publication is verified only after remote receipt/read-back evidence exists.
 
 For any run, the operator should be able to answer:
 
 - What facts were used?
 - Which artifacts were generated?
 - Which checks passed or blocked progression?
+- Did the PR merge gate pass for the code revision?
+- Did the product release gate pass for this exact run/artifact?
 - Which channel was intended and authenticated?
 - Was a remote video already created?
 - What is its current visibility?

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,8 +30,20 @@ tasks:
     desc: "Run Daily Pulse to NotebookLM automation"
     cmds: ["bun --env-file=config/.env src/pulse_to_video_workflow.ts"]
 
+  release:check:
+    desc: "Check run-specific product release conditions without external publication (PROFILE required)"
+    cmds:
+      - |
+        case "{{.PROFILE}}" in
+          byosan) ENV_FILE=config/.env.byosan ;;
+          yawa) ENV_FILE=config/.env.yawa ;;
+          humanity) ENV_FILE=config/.env ;;
+          *) echo "PROFILE must be exactly one of: byosan, yawa, humanity" >&2; exit 2 ;;
+        esac
+        ENV_FILE="$ENV_FILE" YOUTUBE_CHANNEL_PROFILE="{{.PROFILE}}" bun --env-file="$ENV_FILE" src/scripts/check_product_release.ts {{.CLI_ARGS}}
+
   publish:
-    desc: "Publish to YouTube (PROFILE=byosan|yawa|humanity; required)"
+    desc: "Publish to YouTube after the product release gate (PROFILE=byosan|yawa|humanity; required)"
     cmds:
       - |
         case "{{.PROFILE}}" in
@@ -176,13 +188,21 @@ tasks:
     desc: "Run unit tests"
     cmds: ["SKIP_LLM=true DRY_RUN=true bun test"]
 
+  check:merge:fast:
+    desc: "Run the fast deterministic PR merge gate"
+    cmds: ["bun run check:merge:fast"]
+
+  check:merge:
+    desc: "Run the full PR merge gate used by CI"
+    cmds: ["bun run check:merge"]
+
   check:fast:
-    desc: "Run the fast deterministic quality gate used by prek/pre-commit"
-    cmds: ["bun run check:fast"]
+    desc: "Compatibility alias for check:merge:fast"
+    cmds: ["task check:merge:fast"]
 
   check:
-    desc: "Run the full canonical CI quality gate"
-    cmds: ["bun run check"]
+    desc: "Compatibility alias for check:merge"
+    cmds: ["task check:merge"]
 
   clean:
     desc: "Reset logs and temporary artifacts"
@@ -207,11 +227,19 @@ tasks:
     cmds:
       - bun scripts/audit_byosan_money_zero_trust.ts
       - bun src/scripts/audit_byosan_source_registry.ts
-      - bun src/scripts/audit_no_fallback_policy.ts
+      - bun src/scripts/audit_no_fallback_policy.ts --scope=source
+
+  audit:no-fallback:source:
+    desc: "Audit source code for forbidden fallback implementations"
+    cmds: ["bun src/scripts/audit_no_fallback_policy.ts --scope=source"]
+
+  audit:no-fallback:runtime:
+    desc: "Audit runtime deletion evidence for historical fallback publications"
+    cmds: ["bun src/scripts/audit_no_fallback_policy.ts --scope=runtime"]
 
   audit:no-fallback:
-    desc: "Audit the no-fallback policy"
-    cmds: ["bun src/scripts/audit_no_fallback_policy.ts"]
+    desc: "Run both source and runtime no-fallback audits"
+    cmds: ["bun src/scripts/audit_no_fallback_policy.ts --scope=all"]
 
   audit:repo-contract:
     desc: "Verify Taskfile executables and documented repository entry points"

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -1,50 +1,96 @@
 # YT3 quality gates
 
-This repository uses one deterministic quality path locally and in CI.
+YT3 has two independent decision gates. A pull request can be mergeable without any production run being releasable, and a production run can be evaluated for release without changing the definition of code quality.
 
-## Stack and ownership
+## Gate 1: PR merge
 
-| concern | owner | command | notes |
-|---|---|---|---|
-| formatting + lint | Biome | `bun run lint` | one lint owner; no second overlapping linter |
-| TypeScript types | TypeScript compiler | `bun run typecheck` | `tsc --noEmit` remains the type authority |
-| untrusted runtime boundaries | Zod | schema `.parse(...)` at API/artifact/config boundaries | do not add validation to already-trusted internal values |
-| publish safety | repository audits | `bun run audit:publish-routing`, `bun run audit:no-fallback` | fail closed before publish |
-| unit/contract tests | Bun test | `bun run test` | integration behavior remains in CI |
+The PR merge gate answers one question: **is this repository revision safe to merge?**
 
-The canonical commands are:
+Canonical commands:
 
 ```bash
-bun run setup
-bun run check:fast
-bun run check
+task check:merge:fast
+task check:merge
 ```
 
-`check:fast` is the pre-commit/pre-push deterministic gate. `check` adds the Bun test suite and is the CI gate.
+`check:merge:fast` checks only repository/source state:
 
-## Tool decisions
+- Biome formatting and lint
+- TypeScript type safety
+- repository executable/documentation contract
+- static YouTube profile/routing contract
+- source-level no-fallback policy
 
-### Oxlint: not installed
+`check:merge` adds the Bun test suite under `SKIP_LLM=true DRY_RUN=true`.
 
-Oxlint is a valid 2026 TypeScript/JavaScript linter and supports type-aware linting, but adding it here would create a second lint owner beside Biome without a measured migration/parity phase. That violates this repository's single-owner rule. If Biome is replaced later, migrate rules first and remove overlap before making Oxlint canonical.
+The merge gate must not depend on:
 
-Primary docs:
+- production OAuth credentials
+- a specific `RUN_ID`
+- current YouTube remote state
+- historical `runs/` cleanup receipts
+- whether a concrete video is currently ready to publish
 
-- https://oxc.rs/docs/guide/usage/linter/cli
-- https://oxc.rs/docs/guide/usage/linter/type-aware
+GitHub Actions runs `bun run check:merge`. The pre-commit/pre-push hook runs `bun run check:merge:fast`.
 
-### Nx: not installed
+`task check` and `task check:fast` remain compatibility aliases, but new automation and documentation should use the explicit `check:merge*` names.
 
-YT3 is not a genuine multi-project monorepo with an Nx task graph requirement. Adding Nx would increase orchestration surface without replacing a current bottleneck.
+## Gate 2: product release
 
-### prek: configuration only
+The product release gate answers a different question: **is this concrete run/artifact allowed to cross the publication boundary?**
 
-`.pre-commit-config.yaml` defines one local hook whose entry is exactly `bun run check:fast`. `prek` and upstream `pre-commit` can both consume this configuration; neither introduces a second quality implementation.
+Canonical preflight:
 
-Primary docs:
+```bash
+task release:check PROFILE=byosan -- <run-id> [video-path]
+task release:check PROFILE=yawa -- <run-id> [video-path]
+task release:check PROFILE=humanity -- <run-id> [video-path]
+```
 
-- https://prek.j178.dev/reference/cli/
-- https://prek.j178.dev/reference/configuration/
+The release gate is run-specific. It verifies:
+
+- explicit profile and exact profile-to-environment routing
+- run bucket matches the selected channel profile
+- run directory and canonical state exist
+- the selected video artifact exists and has a stable SHA-256 identity
+- fallback-labeled metadata is prohibited
+- canonical publication state does not point at a different artifact
+- unresolved `PRIVATE_UPLOAD_INTENT` / `UNCERTAIN_REMOTE_COMMIT` state without a verified video ID blocks another release
+- factual-integrity evidence passes when configured visibility is non-private
+
+`src/scripts/publish_youtube.ts` executes this gate before OAuth/channel verification or any YouTube publication step. Passing the local product release gate does **not** itself publish anything.
+
+After the local gate passes, the publication path still verifies the authenticated YouTube channel, stages upload state, reads back remote identity/visibility, applies requested visibility, and records publication evidence. Those remote checks are release conditions, not PR merge conditions.
+
+## Runtime policy audits are operational evidence
+
+The no-fallback audit has independent scopes:
+
+```bash
+task audit:no-fallback:source
+task audit:no-fallback:runtime
+task audit:no-fallback
+```
+
+`source` is a merge-time invariant. `runtime` checks historical production deletion evidence. The combined task is useful for operations and audits, but runtime receipt state is intentionally not a PR merge blocker.
+
+## Ownership matrix
+
+| concern | owner | merge gate | release gate |
+|---|---|---:|---:|
+| formatting + lint | Biome | yes | no |
+| TypeScript types | TypeScript compiler | yes | no |
+| executable/docs contract | repository audit | yes | no |
+| static channel routing | repository audit | yes | inherited invariant |
+| source no-fallback policy | repository audit | yes | inherited invariant |
+| unit/contract tests | Bun test | yes | no |
+| concrete run state | product release gate | no | yes |
+| artifact identity | product release gate | no | yes |
+| factual-integrity evidence | product release gate | no | yes |
+| canonical publication conflict state | product release gate | no | yes |
+| authenticated remote channel | YouTube publication path | no | yes |
+| remote visibility/read-back | YouTube publication path | no | yes |
+| historical fallback deletion receipts | runtime audit | no | operational |
 
 ## Fresh-clone contract
 
@@ -52,17 +98,29 @@ A clean checkout needs Bun, then:
 
 ```bash
 bun run setup
-bun run check
+bun run check:merge
 ```
 
-`setup` uses `bun install --frozen-lockfile`, so CI refuses dependency-resolution drift when a Bun lockfile is present. This repository does not add a second package manager or parallel lockfile.
+`setup` uses `bun ci` with the committed `bun.lock`; dependency-resolution drift therefore fails rather than silently rewriting the dependency graph.
 
 ## Boundary validation
 
-Zod is already a runtime dependency and is used for external/state/artifact boundaries. New boundary work should parse the untrusted value once, then pass typed data inward. Examples include `AgentStateSchema`, dancer manifest import, YouTube Analytics evidence, and canonical publication-state parsing.
+Zod remains the runtime boundary parser for untrusted API, artifact, configuration, and persisted-state inputs. New boundary work should parse once, then pass typed values inward. Release readiness is kept separate from merge readiness even when both reuse the same typed domain models.
 
-## CI timing evidence
+## Tool decisions
 
-The previous CI split typecheck, Biome, publish audits and tests into separate workflow steps. The current workflow invokes the same sequence through `bun run check`, removing duplicated orchestration rather than removing checks.
+### Oxlint: not installed
 
-For each migration PR, GitHub Actions run duration is the before/after timing evidence. Record the exact-head run in the PR before merge; do not claim a speedup without that measured run.
+Adding Oxlint would create a second lint owner beside Biome without a measured migration/parity phase. If Biome is replaced later, migrate rules first and remove overlap before making another linter canonical.
+
+### Nx: not installed
+
+YT3 is not a genuine multi-project monorepo with an Nx task-graph requirement. Adding Nx would increase orchestration surface without replacing a current bottleneck.
+
+### prek / pre-commit
+
+`.pre-commit-config.yaml` contains one local hook whose entry is `bun run check:merge:fast`. `prek` and upstream `pre-commit` can both consume the same configuration; neither defines a separate quality implementation.
+
+## CI evidence
+
+For repository-change PRs, inspect the GitHub Actions result on the exact PR head SHA before merge. A passing merge gate proves repository acceptance criteria only; do not reinterpret it as proof that a concrete product run is releasable or published.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
 		"format": "bun biome format --write src tests",
 		"typecheck": "bun x tsc --noEmit",
 		"audit:repo-contract": "bun src/scripts/audit_repository_contract.ts",
-		"check:fast": "bun run lint && bun run typecheck && bun run audit:repo-contract && bun src/scripts/audit_publish_routing.ts && bun src/scripts/audit_no_fallback_policy.ts",
-		"check": "bun run check:fast && SKIP_LLM=true DRY_RUN=true bun run test"
+		"audit:no-fallback:source": "bun src/scripts/audit_no_fallback_policy.ts --scope=source",
+		"check:merge:fast": "bun run lint && bun run typecheck && bun run audit:repo-contract && bun src/scripts/audit_publish_routing.ts && bun run audit:no-fallback:source",
+		"check:merge": "bun run check:merge:fast && SKIP_LLM=true DRY_RUN=true bun run test",
+		"check:fast": "bun run check:merge:fast",
+		"check": "bun run check:merge"
 	},
 	"repository": {
 		"type": "git",

--- a/src/domain/product_release_gate.ts
+++ b/src/domain/product_release_gate.ts
@@ -70,12 +70,15 @@ export function assertProductReleaseGate(
 
 	assertNoFallbackMetadata(state);
 
-	const artifactPath = publishVideoPath || state.publish_video_path || state.video_path;
+	const artifactPath =
+		publishVideoPath || state.publish_video_path || state.video_path;
 	if (!artifactPath) {
 		throw new Error("Product release blocked: video path is missing");
 	}
 	if (!fs.existsSync(artifactPath)) {
-		throw new Error(`Product release blocked: video path does not exist: ${artifactPath}`);
+		throw new Error(
+			`Product release blocked: video path does not exist: ${artifactPath}`,
+		);
 	}
 
 	const artifactSha256 = sha256File(artifactPath);

--- a/src/domain/product_release_gate.ts
+++ b/src/domain/product_release_gate.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import fs from "fs-extra";
+import {
+	assertFactualIntegrityGate,
+	assertNoLegacyPublishState,
+	loadPublicationState,
+	sha256File,
+} from "./publication_state.js";
+import type { AgentState } from "./types.js";
+import type { YouTubeProfile } from "./youtube_profiles.js";
+
+export type ProductReleaseGateInput = {
+	runDir: string;
+	runId: string;
+	state: AgentState & { source_manifest_path?: string };
+	profile: YouTubeProfile;
+	publishVideoPath?: string;
+	requireFactualIntegrity: boolean;
+};
+
+export type ProductReleaseGateResult = {
+	runId: string;
+	profile: string;
+	bucket: string;
+	artifactPath: string;
+	artifactSha256: string;
+	factualIntegrityAttestation?: string;
+};
+
+function assertNoFallbackMetadata(state: AgentState): void {
+	const metadata = state.metadata;
+	const metadataText = [
+		metadata?.title,
+		metadata?.description,
+		metadata?.thumbnail_title,
+		...(metadata?.tags || []),
+	]
+		.filter(Boolean)
+		.join("\n")
+		.toLowerCase();
+
+	if (
+		/\bfallback\b/.test(metadataText) ||
+		metadataText.includes("reused because") ||
+		metadataText.includes("cached fallback")
+	) {
+		throw new Error(
+			"Product release blocked: fallback metadata is prohibited and must be deleted, not published.",
+		);
+	}
+}
+
+export function assertProductReleaseGate(
+	input: ProductReleaseGateInput,
+): ProductReleaseGateResult {
+	const {
+		runDir,
+		runId,
+		state,
+		profile,
+		publishVideoPath,
+		requireFactualIntegrity,
+	} = input;
+
+	if (state.bucket !== profile.bucket) {
+		throw new Error(
+			`Product release blocked: run bucket '${state.bucket}' does not match profile bucket '${profile.bucket}' for '${profile.profileName}'`,
+		);
+	}
+
+	assertNoFallbackMetadata(state);
+
+	const artifactPath = publishVideoPath || state.publish_video_path || state.video_path;
+	if (!artifactPath) {
+		throw new Error("Product release blocked: video path is missing");
+	}
+	if (!fs.existsSync(artifactPath)) {
+		throw new Error(`Product release blocked: video path does not exist: ${artifactPath}`);
+	}
+
+	const artifactSha256 = sha256File(artifactPath);
+	const stored = loadPublicationState(runDir);
+	if (stored && stored.artifact_sha256 !== artifactSha256) {
+		throw new Error(
+			"Product release blocked: canonical publication state belongs to a different artifact hash",
+		);
+	}
+	if (
+		stored &&
+		!stored.video_id &&
+		(stored.phase === "PRIVATE_UPLOAD_INTENT" ||
+			stored.phase === "UNCERTAIN_REMOTE_COMMIT")
+	) {
+		throw new Error(
+			`Product release blocked: canonical publish state is ${stored.phase} without a verified video id`,
+		);
+	}
+	if (!stored) assertNoLegacyPublishState(runDir);
+
+	let factualIntegrityAttestation: string | undefined;
+	if (requireFactualIntegrity) {
+		factualIntegrityAttestation = assertFactualIntegrityGate(runDir, state);
+	}
+
+	return {
+		runId,
+		profile: profile.profileName,
+		bucket: profile.bucket,
+		artifactPath: path.resolve(artifactPath),
+		artifactSha256,
+		factualIntegrityAttestation,
+	};
+}

--- a/src/scripts/audit_no_fallback_policy.ts
+++ b/src/scripts/audit_no_fallback_policy.ts
@@ -46,7 +46,9 @@ function resolveScope(args: string[]): AuditScope {
 		?.slice("--scope=".length);
 	if (!raw) return "all";
 	if (raw === "source" || raw === "runtime" || raw === "all") return raw;
-	throw new Error(`Unknown audit scope '${raw}'. Expected source, runtime, or all.`);
+	throw new Error(
+		`Unknown audit scope '${raw}'. Expected source, runtime, or all.`,
+	);
 }
 
 function listFiles(target: string): string[] {

--- a/src/scripts/audit_no_fallback_policy.ts
+++ b/src/scripts/audit_no_fallback_policy.ts
@@ -141,20 +141,23 @@ function formatMarkdown(scope: AuditScope, checks: Check[]): string {
 	return lines.join("\n");
 }
 
+function outputStem(scope: AuditScope): string {
+	return scope === "all"
+		? "no_fallback_policy_audit"
+		: `no_fallback_policy_audit.${scope}`;
+}
+
 async function main() {
 	const scope = resolveScope(process.argv.slice(2));
 	const checks = checksForScope(scope);
 	const outDir = path.join(ROOT, "logs");
+	const stem = outputStem(scope);
 	await fs.ensureDir(outDir);
-	await fs.writeJson(
-		path.join(outDir, `no_fallback_policy_audit.${scope}.json`),
-		checks,
-		{
-			spaces: 2,
-		},
-	);
+	await fs.writeJson(path.join(outDir, `${stem}.json`), checks, {
+		spaces: 2,
+	});
 	await fs.writeFile(
-		path.join(outDir, `no_fallback_policy_audit.${scope}.md`),
+		path.join(outDir, `${stem}.md`),
 		`${formatMarkdown(scope, checks)}\n`,
 	);
 	console.log(formatMarkdown(scope, checks));

--- a/src/scripts/audit_no_fallback_policy.ts
+++ b/src/scripts/audit_no_fallback_policy.ts
@@ -7,6 +7,8 @@ type Check = {
 	details: string;
 };
 
+type AuditScope = "source" | "runtime" | "all";
+
 const ROOT = process.cwd();
 const SOURCE_ROOTS = [
 	"src",
@@ -36,6 +38,15 @@ function pass(name: string, details: string): Check {
 
 function fail(name: string, details: string): Check {
 	return { name, status: "FAIL", details };
+}
+
+function resolveScope(args: string[]): AuditScope {
+	const raw = args
+		.find((arg) => arg.startsWith("--scope="))
+		?.slice("--scope=".length);
+	if (!raw) return "all";
+	if (raw === "source" || raw === "runtime" || raw === "all") return raw;
+	throw new Error(`Unknown audit scope '${raw}'. Expected source, runtime, or all.`);
 }
 
 function listFiles(target: string): string[] {
@@ -115,9 +126,15 @@ function auditFallbackReceipts(): Check {
 		: fail("fallback_receipts_deleted", failures.join("; "));
 }
 
-function formatMarkdown(checks: Check[]): string {
+function checksForScope(scope: AuditScope): Check[] {
+	if (scope === "source") return [scanForbiddenCode()];
+	if (scope === "runtime") return [auditFallbackReceipts()];
+	return [scanForbiddenCode(), auditFallbackReceipts()];
+}
+
+function formatMarkdown(scope: AuditScope, checks: Check[]): string {
 	const lines = ["# No Fallback Policy Audit", ""];
-	lines.push(`Generated: ${new Date().toISOString()}`, "");
+	lines.push(`Scope: ${scope}`, `Generated: ${new Date().toISOString()}`, "");
 	for (const check of checks) {
 		lines.push(`- ${check.status} ${check.name}: ${check.details}`);
 	}
@@ -125,21 +142,22 @@ function formatMarkdown(checks: Check[]): string {
 }
 
 async function main() {
-	const checks = [scanForbiddenCode(), auditFallbackReceipts()];
+	const scope = resolveScope(process.argv.slice(2));
+	const checks = checksForScope(scope);
 	const outDir = path.join(ROOT, "logs");
 	await fs.ensureDir(outDir);
 	await fs.writeJson(
-		path.join(outDir, "no_fallback_policy_audit.json"),
+		path.join(outDir, `no_fallback_policy_audit.${scope}.json`),
 		checks,
 		{
 			spaces: 2,
 		},
 	);
 	await fs.writeFile(
-		path.join(outDir, "no_fallback_policy_audit.md"),
-		`${formatMarkdown(checks)}\n`,
+		path.join(outDir, `no_fallback_policy_audit.${scope}.md`),
+		`${formatMarkdown(scope, checks)}\n`,
 	);
-	console.log(formatMarkdown(checks));
+	console.log(formatMarkdown(scope, checks));
 	if (checks.some((check) => check.status === "FAIL")) process.exit(1);
 }
 

--- a/src/scripts/audit_publish_routing.ts
+++ b/src/scripts/audit_publish_routing.ts
@@ -116,7 +116,7 @@ function assertProfileRegistry() {
 function assertFailClosedProfileTask(
 	taskName: string,
 	task: TaskDefinition,
-	executable: string,
+	invocation: string,
 ) {
 	const command = getSingleCommand(taskName, task);
 
@@ -144,10 +144,10 @@ function assertFailClosedProfileTask(
 		);
 	}
 
-	const canonicalInvocation = `ENV_FILE="$ENV_FILE" YOUTUBE_CHANNEL_PROFILE="{{.PROFILE}}" bun ${executable} {{.CLI_ARGS}}`;
+	const canonicalInvocation = `ENV_FILE="$ENV_FILE" YOUTUBE_CHANNEL_PROFILE="{{.PROFILE}}" ${invocation} {{.CLI_ARGS}}`;
 	if (!command.includes(canonicalInvocation)) {
 		throw new Error(
-			`Task ${taskName} must invoke only ${executable} after exact profile routing`,
+			`Task ${taskName} must invoke only '${invocation}' after exact profile routing`,
 		);
 	}
 
@@ -158,6 +158,18 @@ function assertFailClosedProfileTask(
 	}
 }
 
+function assertCanonicalReleaseCheckTask(tasks: Record<string, TaskDefinition>) {
+	const task = tasks["release:check"];
+	if (!task) {
+		throw new Error("Taskfile.yml is missing canonical task release:check");
+	}
+	assertFailClosedProfileTask(
+		"release:check",
+		task,
+		'bun --env-file="$ENV_FILE" src/scripts/check_product_release.ts',
+	);
+}
+
 function assertCanonicalPublishTask(tasks: Record<string, TaskDefinition>) {
 	const task = tasks.publish;
 	if (!task) {
@@ -166,7 +178,7 @@ function assertCanonicalPublishTask(tasks: Record<string, TaskDefinition>) {
 	assertFailClosedProfileTask(
 		"publish",
 		task,
-		"src/scripts/publish_youtube.ts",
+		"bun src/scripts/publish_youtube.ts",
 	);
 }
 
@@ -175,7 +187,11 @@ function assertCanonicalAuthTask(tasks: Record<string, TaskDefinition>) {
 	if (!task) {
 		throw new Error("Taskfile.yml is missing canonical task auth");
 	}
-	assertFailClosedProfileTask("auth", task, "src/scripts/youtube_oauth.ts");
+	assertFailClosedProfileTask(
+		"auth",
+		task,
+		"bun src/scripts/youtube_oauth.ts",
+	);
 }
 
 function assertSafeAliases(tasks: Record<string, TaskDefinition>) {
@@ -223,6 +239,7 @@ async function main() {
 		throw new Error("Taskfile.yml does not contain a tasks section");
 	}
 
+	assertCanonicalReleaseCheckTask(taskfile.tasks);
 	assertCanonicalPublishTask(taskfile.tasks);
 	assertCanonicalAuthTask(taskfile.tasks);
 	assertSafeAliases(taskfile.tasks);

--- a/src/scripts/audit_publish_routing.ts
+++ b/src/scripts/audit_publish_routing.ts
@@ -158,7 +158,9 @@ function assertFailClosedProfileTask(
 	}
 }
 
-function assertCanonicalReleaseCheckTask(tasks: Record<string, TaskDefinition>) {
+function assertCanonicalReleaseCheckTask(
+	tasks: Record<string, TaskDefinition>,
+) {
 	const task = tasks["release:check"];
 	if (!task) {
 		throw new Error("Taskfile.yml is missing canonical task release:check");
@@ -187,11 +189,7 @@ function assertCanonicalAuthTask(tasks: Record<string, TaskDefinition>) {
 	if (!task) {
 		throw new Error("Taskfile.yml is missing canonical task auth");
 	}
-	assertFailClosedProfileTask(
-		"auth",
-		task,
-		"bun src/scripts/youtube_oauth.ts",
-	);
+	assertFailClosedProfileTask("auth", task, "bun src/scripts/youtube_oauth.ts");
 }
 
 function assertSafeAliases(tasks: Record<string, TaskDefinition>) {

--- a/src/scripts/check_product_release.ts
+++ b/src/scripts/check_product_release.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { assertProductReleaseGate } from "../domain/product_release_gate.js";
+import { AgentStateSchema } from "../domain/types.js";
+import {
+	assertProfileEnvFile,
+	getYouTubeProfile,
+} from "../domain/youtube_profiles.js";
+import { loadConfig } from "../io/core.js";
+
+function resolveRunId(rawRunId: string, bucket: string): string {
+	const runId = rawRunId.includes("/") ? rawRunId : `${bucket}/${rawRunId}`;
+	const parts = runId.split("/");
+	if (parts.length !== 2 || parts[0] !== bucket || !parts[1]) {
+		throw new Error(
+			`Product release requires RUN_ID in '${bucket}/<run>' form; got '${rawRunId}'`,
+		);
+	}
+	return runId;
+}
+
+async function main() {
+	const profile = getYouTubeProfile();
+	assertProfileEnvFile(profile, process.env.ENV_FILE);
+
+	const rawRunId = process.env.RUN_ID || process.argv[2];
+	if (!rawRunId) {
+		throw new Error(
+			`RUN_ID is required for product release profile '${profile.profileName}'`,
+		);
+	}
+	const runId = resolveRunId(rawRunId, profile.bucket);
+	const runName = runId.split("/")[1];
+	if (!runName) throw new Error(`Malformed RUN_ID '${runId}'`);
+
+	const cfg = loadConfig(profile.bucket);
+	const runDir = path.join(
+		process.cwd(),
+		cfg.workflow.paths.runs_dir,
+		profile.bucket,
+		runName,
+	);
+	if (!fs.existsSync(runDir)) {
+		throw new Error(`Product release blocked: run directory does not exist: ${runDir}`);
+	}
+
+	const statePath = path.join(runDir, cfg.workflow.filenames.state);
+	if (!fs.existsSync(statePath)) {
+		throw new Error(`Product release blocked: state file does not exist: ${statePath}`);
+	}
+	const state = AgentStateSchema.passthrough().parse(fs.readJsonSync(statePath)) as ReturnType<
+		typeof AgentStateSchema.parse
+	> & { source_manifest_path?: string };
+	const publishVideoPath = process.argv[3]?.trim() || undefined;
+	const requireFactualIntegrity = cfg.steps.youtube?.default_visibility !== "private";
+
+	const result = assertProductReleaseGate({
+		runDir,
+		runId,
+		state,
+		profile,
+		publishVideoPath,
+		requireFactualIntegrity,
+	});
+
+	console.log(
+		`[product-release-gate] PASS profile=${result.profile} run=${result.runId} artifact_sha256=${result.artifactSha256}`,
+	);
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.message : error);
+	process.exit(1);
+});

--- a/src/scripts/check_product_release.ts
+++ b/src/scripts/check_product_release.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "fs-extra";
 import { assertProductReleaseGate } from "../domain/product_release_gate.js";
-import { AgentStateSchema, type AgentState } from "../domain/types.js";
+import { type AgentState, AgentStateSchema } from "../domain/types.js";
 import {
 	assertProfileEnvFile,
 	getYouTubeProfile,
@@ -41,18 +41,25 @@ async function main() {
 		runName,
 	);
 	if (!fs.existsSync(runDir)) {
-		throw new Error(`Product release blocked: run directory does not exist: ${runDir}`);
+		throw new Error(
+			`Product release blocked: run directory does not exist: ${runDir}`,
+		);
 	}
 
 	const statePath = path.join(runDir, cfg.workflow.filenames.state);
 	if (!fs.existsSync(statePath)) {
-		throw new Error(`Product release blocked: state file does not exist: ${statePath}`);
+		throw new Error(
+			`Product release blocked: state file does not exist: ${statePath}`,
+		);
 	}
-	const state = AgentStateSchema.passthrough().parse(fs.readJsonSync(statePath)) as AgentState & {
+	const state = AgentStateSchema.passthrough().parse(
+		fs.readJsonSync(statePath),
+	) as AgentState & {
 		source_manifest_path?: string;
 	};
 	const publishVideoPath = process.argv[3]?.trim() || undefined;
-	const requireFactualIntegrity = cfg.steps.youtube?.default_visibility !== "private";
+	const requireFactualIntegrity =
+		cfg.steps.youtube?.default_visibility !== "private";
 
 	const result = assertProductReleaseGate({
 		runDir,

--- a/src/scripts/check_product_release.ts
+++ b/src/scripts/check_product_release.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "fs-extra";
 import { assertProductReleaseGate } from "../domain/product_release_gate.js";
-import { AgentStateSchema } from "../domain/types.js";
+import { AgentStateSchema, type AgentState } from "../domain/types.js";
 import {
 	assertProfileEnvFile,
 	getYouTubeProfile,
@@ -48,9 +48,9 @@ async function main() {
 	if (!fs.existsSync(statePath)) {
 		throw new Error(`Product release blocked: state file does not exist: ${statePath}`);
 	}
-	const state = AgentStateSchema.passthrough().parse(fs.readJsonSync(statePath)) as ReturnType<
-		typeof AgentStateSchema.parse
-	> & { source_manifest_path?: string };
+	const state = AgentStateSchema.passthrough().parse(fs.readJsonSync(statePath)) as AgentState & {
+		source_manifest_path?: string;
+	};
 	const publishVideoPath = process.argv[3]?.trim() || undefined;
 	const requireFactualIntegrity = cfg.steps.youtube?.default_visibility !== "private";
 

--- a/src/scripts/publish_youtube.ts
+++ b/src/scripts/publish_youtube.ts
@@ -20,6 +20,31 @@ const envFilePath = path.isAbsolute(envFile)
 
 dotenv.config({ path: envFilePath, override: true });
 
+async function runBunScript(script: string, args: string[]): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn(
+			"bun",
+			[`--env-file=${envFile}`, script, ...args].filter(Boolean),
+			{
+				cwd: process.cwd(),
+				env: process.env,
+				stdio: "inherit",
+			},
+		);
+
+		child.on("error", reject);
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(
+					new Error(`${script} failed with exit code ${code ?? "null"}`),
+				);
+			}
+		});
+	});
+}
+
 async function main() {
 	const profile = getYouTubeProfile();
 	assertProfileEnvFile(profile, process.env.ENV_FILE);
@@ -35,6 +60,11 @@ async function main() {
 		process.env.PUBLISH_VIDEO_PATH = publishVideoPathArg;
 		console.log(`PUBLISH_VIDEO_PATH=${publishVideoPathArg}`);
 	}
+
+	await runBunScript(
+		"src/scripts/check_product_release.ts",
+		[runId, publishVideoPathArg || ""].filter(Boolean),
+	);
 
 	const clientId = process.env.YOUTUBE_CLIENT_ID;
 	const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
@@ -58,34 +88,10 @@ async function main() {
 	console.log(result.actual.title);
 	console.log(result.actual.handle ?? "");
 
-	await new Promise<void>((resolve, reject) => {
-		const child = spawn(
-			"bun",
-			[
-				`--env-file=${envFile}`,
-				"src/step.ts",
-				"publish",
-				runId,
-				publishVideoPathArg || "",
-			].filter(Boolean),
-			{
-				cwd: process.cwd(),
-				env: process.env,
-				stdio: "inherit",
-			},
-		);
-
-		child.on("error", reject);
-		child.on("exit", (code) => {
-			if (code === 0) {
-				resolve();
-			} else {
-				reject(
-					new Error(`Publish step failed with exit code ${code ?? "null"}`),
-				);
-			}
-		});
-	});
+	await runBunScript(
+		"src/step.ts",
+		["publish", runId, publishVideoPathArg || ""].filter(Boolean),
+	);
 }
 
 main().catch((error) => {

--- a/src/scripts/publish_youtube.ts
+++ b/src/scripts/publish_youtube.ts
@@ -22,15 +22,11 @@ dotenv.config({ path: envFilePath, override: true });
 
 async function runBunScript(script: string, args: string[]): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
-		const child = spawn(
-			"bun",
-			[`--env-file=${envFile}`, script, ...args].filter(Boolean),
-			{
-				cwd: process.cwd(),
-				env: process.env,
-				stdio: "inherit",
-			},
-		);
+		const child = spawn("bun", [`--env-file=${envFile}`, script, ...args], {
+			cwd: process.cwd(),
+			env: process.env,
+			stdio: "inherit",
+		});
 
 		child.on("error", reject);
 		child.on("exit", (code) => {
@@ -61,10 +57,10 @@ async function main() {
 		console.log(`PUBLISH_VIDEO_PATH=${publishVideoPathArg}`);
 	}
 
-	await runBunScript(
-		"src/scripts/check_product_release.ts",
-		[runId, publishVideoPathArg || ""].filter(Boolean),
-	);
+	await runBunScript("src/scripts/check_product_release.ts", [
+		runId,
+		publishVideoPathArg || "",
+	]);
 
 	const clientId = process.env.YOUTUBE_CLIENT_ID;
 	const clientSecret = process.env.YOUTUBE_CLIENT_SECRET;
@@ -88,10 +84,12 @@ async function main() {
 	console.log(result.actual.title);
 	console.log(result.actual.handle ?? "");
 
-	await runBunScript(
-		"src/step.ts",
-		["publish", runId, publishVideoPathArg || ""].filter(Boolean),
-	);
+	await runBunScript("src/step.ts", [
+		"publish",
+		runId,
+		"",
+		publishVideoPathArg || "",
+	]);
 }
 
 main().catch((error) => {

--- a/src/scripts/publish_youtube.ts
+++ b/src/scripts/publish_youtube.ts
@@ -33,9 +33,7 @@ async function runBunScript(script: string, args: string[]): Promise<void> {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(
-					new Error(`${script} failed with exit code ${code ?? "null"}`),
-				);
+				reject(new Error(`${script} failed with exit code ${code ?? "null"}`));
 			}
 		});
 	});

--- a/tests/product_release_gate.test.ts
+++ b/tests/product_release_gate.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import fs from "fs-extra";
+import { assertProductReleaseGate } from "../src/domain/product_release_gate.js";
+import type { AgentState } from "../src/domain/types.js";
+import { YOUTUBE_PROFILES } from "../src/domain/youtube_profiles.js";
+
+function tempRun(name: string): string {
+	const dir = path.join(
+		process.cwd(),
+		".tmp-product-release-tests",
+		`${name}-${randomUUID()}`,
+	);
+	fs.ensureDirSync(dir);
+	return dir;
+}
+
+function readyState(runDir: string): AgentState {
+	const videoPath = path.join(runDir, "video.mp4");
+	fs.writeFileSync(videoPath, "release-artifact");
+	fs.ensureDirSync(path.join(runDir, "audit"));
+	fs.writeJsonSync(path.join(runDir, "audit", "result.json"), {
+		provenance: { status: "PASS", critical: true },
+		script_integrity: { status: "PASS", critical: true },
+	});
+	return {
+		run_id: "byosan_money/test",
+		bucket: "byosan_money",
+		video_path: videoPath,
+		metadata: {
+			title: "Release candidate",
+			thumbnail_title: "Release candidate",
+			description: "Verified description",
+			tags: ["finance"],
+		},
+	};
+}
+
+describe("product release gate", () => {
+	test("passes a concrete audited artifact and writes factual-integrity evidence", () => {
+		const runDir = tempRun("pass");
+		try {
+			const result = assertProductReleaseGate({
+				runDir,
+				runId: "byosan_money/test",
+				state: readyState(runDir),
+				profile: YOUTUBE_PROFILES.byosan,
+				requireFactualIntegrity: true,
+			});
+			expect(result.profile).toBe("byosan");
+			expect(result.artifactSha256).toHaveLength(64);
+			expect(result.factualIntegrityAttestation).toBeTruthy();
+			expect(
+				fs.existsSync(result.factualIntegrityAttestation || "missing"),
+			).toBe(true);
+		} finally {
+			fs.removeSync(runDir);
+		}
+	});
+
+	test("fails closed when the run bucket and release profile differ", () => {
+		const runDir = tempRun("bucket");
+		try {
+			const state = readyState(runDir);
+			state.bucket = "humanity_observatory";
+			expect(() =>
+				assertProductReleaseGate({
+					runDir,
+					runId: "byosan_money/test",
+					state,
+					profile: YOUTUBE_PROFILES.byosan,
+					requireFactualIntegrity: true,
+				}),
+			).toThrow("does not match profile bucket");
+		} finally {
+			fs.removeSync(runDir);
+		}
+	});
+
+	test("blocks fallback-labeled product metadata", () => {
+		const runDir = tempRun("fallback");
+		try {
+			const state = readyState(runDir);
+			if (!state.metadata) throw new Error("test metadata missing");
+			state.metadata.description = "cached fallback output";
+			expect(() =>
+				assertProductReleaseGate({
+					runDir,
+					runId: "byosan_money/test",
+					state,
+					profile: YOUTUBE_PROFILES.byosan,
+					requireFactualIntegrity: true,
+				}),
+			).toThrow("fallback metadata is prohibited");
+		} finally {
+			fs.removeSync(runDir);
+		}
+	});
+});


### PR DESCRIPTION
## Contract

Separate repository merge acceptance from concrete product release readiness.

- PR merge must depend only on repository/source invariants and deterministic tests.
- Historical runtime receipts, production credentials, a specific RUN_ID, and current YouTube state must not block unrelated code merges.
- Product release must be evaluated independently for an explicit profile + run + artifact before YouTube side effects.
- Existing fail-closed publication semantics and channel isolation must remain intact.

## Changes

- Add explicit `check:merge` / `check:merge:fast` gates and make CI/pre-commit use them.
- Split no-fallback auditing into source and runtime scopes; only source scope participates in merge acceptance.
- Add `release:check` with run-specific artifact/profile/audit/publication-state validation.
- Enforce the product release preflight before the canonical manual YouTube publish path reaches OAuth/remote publication work.
- Add product-release-gate tests and update gate ownership documentation.
- Preserve `check` / `check:fast` as compatibility aliases.

## Acceptance

- `bun ci` succeeds from the committed lockfile.
- `bun run check:merge` passes on the exact PR head.
- Repository-contract and static publish-routing audits pass.
- Source no-fallback policy passes without consulting runtime receipt cleanup state.
- Product release gate tests pass.
- No YouTube publication or other external product release is performed by this PR.