### PR TITLE
Make mergeability and product verification orthogonal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,23 +80,41 @@ task daily:guarantee-status
 
 Internal package scripts and `src/scripts/*` support Taskfile and CI. They are not a second human-facing command surface unless the repository explicitly makes them one.
 
-## 5. PR merge and product release are separate gates
+## 5. Repository acceptance and product evidence are orthogonal
 
-Never use one gate as evidence for the other.
+Maintain independent verdicts for repository state and product/runtime state. Never derive one from the other.
+
+| evidence/state | proves | does not prove |
+|---|---|---|
+| `task check:merge` / green CI | repository revision satisfies merge criteria | product works, is complete, is releasable, or was released |
+| target machine/service unavailable | target-environment behavior is UNVERIFIED | repository revision is unmergeable |
+| deterministic simulator/mock/contract test passes | tested repository contract holds | real target behavior occurred |
+| `task release:check` passes | concrete artifact passes local release preflight | remote publication occurred |
+| remote receipt/read-back passes | specified external postcondition occurred | repository/source quality |
 
 ### Merge gate
 
-`task check:merge` decides whether a repository revision is acceptable to merge. It is limited to repository/source invariants and deterministic tests. It must not depend on production credentials, a concrete `RUN_ID`, current YouTube state, or historical runtime cleanup receipts.
+`task check:merge` decides whether a repository revision is acceptable to merge. It is limited to repository/source invariants and deterministic tests executable in the supported development/CI environment.
 
-A green CI run proves only that merge criteria passed for that commit.
+**The absence of a real machine, production credential, concrete run, or reachable production service is not a merge blocker.** Do not report “cannot merge because the real environment is unavailable”. Hardware/service-specific code must expose a deterministic merge-time boundary that can be checked without the target environment: typed interfaces, schema/contract tests, fixtures, mocks, emulators, simulators, static checks, or another reproducible substitute appropriate to that boundary.
 
-### Product release gate
+If behavior can only be proven on the real target, keep that product/runtime criterion **UNVERIFIED** and move it to product qualification or release verification. Do not convert missing target-environment evidence into a repository failure.
+
+The merge gate must not depend on production credentials, a concrete `RUN_ID`, current YouTube state, historical runtime cleanup receipts, or availability of a particular production machine.
+
+A green CI run proves only that merge criteria passed for that exact commit.
+
+### Product qualification and release
+
+Product completion is a separate claim. It requires direct evidence for the product acceptance criteria in the environment where those criteria are defined.
+
+**Green CI is never sufficient evidence that the product is complete.** Do not report “finished”, “production verified”, “works on the real machine”, or equivalent product-level success solely from repository tests or CI.
 
 `task release:check PROFILE=<profile> -- <run-id> [video-path]` evaluates one concrete run/artifact before it may cross the publication boundary. It checks run/profile alignment, artifact identity, factual-integrity evidence, fallback prohibition, and publication-conflict state.
 
 A passing release check does not prove publication occurred. Remote channel identity, publication receipt, and final visibility require separate evidence.
 
-Do not run product-release checks merely to prove a code PR is mergeable. Do not treat a merge-gate PASS as release evidence.
+Do not run product-release checks merely to prove a code PR is mergeable. Do not treat a merge-gate PASS as product qualification or release evidence.
 
 ## 6. Fail closed at real boundaries
 
@@ -107,6 +125,8 @@ Prefer attributable failure over false success.
 - do not invent substitute data for required missing inputs
 - do not publish fallback media as the requested artifact
 - missing dependencies, timeouts, crashes, missing receipts, or ambiguous profiles block only the criterion they prevent proving
+
+A missing real environment blocks only claims that require that environment. It must not contaminate independent repository acceptance criteria.
 
 When a failure pattern repeats, improve the durable harness: validation, schema, routing, retry policy, eval, observability, or implementation. Do not accumulate ad-hoc recovery paths.
 
@@ -155,12 +175,15 @@ For repository changes, escalate only as needed:
 6. full domain/harness audit when relevant
 7. CI on the exact PR head SHA
 
+These steps establish repository evidence. They do not establish product completion unless a product acceptance criterion explicitly is identical to one of those checks.
+
 For an explicitly requested product release, use a separate ladder after the repository revision is known:
 
 1. `task release:check PROFILE=<profile> -- <run-id> [video-path]`
-2. authenticated channel verification
-3. remote publication action when authorized
-4. remote receipt/read-back/visibility verification
+2. target/runtime qualification required by the product contract
+3. authenticated channel verification
+4. remote publication action when authorized
+5. remote receipt/read-back/visibility verification
 
 Implementation intent is not acceptance evidence. Treat builder and auditor as separate roles even when the same agent performs them sequentially.
 
@@ -174,8 +197,10 @@ For repository changes:
 4. update the canonical PR rather than opening a competing one;
 5. inspect CI for the exact head SHA;
 6. diagnose failures rather than retrying blindly;
-7. merge only when merge acceptance criteria and repository policy allow it;
+7. merge when repository merge acceptance criteria and policy pass, regardless of whether unrelated product/runtime verification is currently possible;
 8. after merge, verify the intended base state and remove task-created residue when possible.
+
+Do not hold a merge open solely because target hardware or a production environment is unavailable. Record the unverified product criterion separately and preserve its exact verification action.
 
 Before final reporting, inspect for temporary files, debug output, staging chunks, abandoned intermediates, one-time workflows/scripts, superseded worklines, and stale task/document references.
 
@@ -202,13 +227,15 @@ Do not make ChatGPT Work, Codex, or another external agent workspace a required 
 
 Never expose secrets, OAuth credentials, private tokens, local absolute paths, or private intermediate metadata in public artifacts. Do not copy production credentials or account identifiers into tests, docs, prompts, or screenshots.
 
-Work is complete only when:
+Repository work is complete when:
 
-- the requested outcome exists in the final state;
-- acceptance evidence belongs to that final state;
-- required CI and external postconditions are verified;
+- the requested repository outcome exists in the final state;
+- merge acceptance evidence belongs to that final state;
+- required repository CI is verified;
 - task-created residue is removed or intentionally retained on the canonical workline;
-- no known blocker remains.
+- no repository-level blocker remains.
+
+Product completion is a different verdict. Report it only when every product-level acceptance criterion has direct evidence from the required runtime, artifact, service, or external postcondition. If the required environment was unavailable, report that criterion as UNVERIFIED; do not downgrade repository mergeability and do not upgrade product status from CI.
 
 Report only verified state relevant to the task:
 
@@ -216,9 +243,10 @@ Report only verified state relevant to the task:
 - what changed
 - deterministic checks actually executed and their results
 - commit/PR/merge state
+- product/runtime qualification only when actually executed
 - product release result only when a concrete run was checked
 - external receipt only when external state changed
 - cleanup performed
 - blocker and exact next action if unfinished
 
-Stop at this fixed point. Further work is scope expansion.
+Stop at the fixed point for the requested scope. Further work is scope expansion.

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -1,10 +1,26 @@
 # YT3 quality gates
 
-YT3 has two independent decision gates. A pull request can be mergeable without any production run being releasable, and a production run can be evaluated for release without changing the definition of code quality.
+YT3 keeps repository acceptance and product/runtime evidence orthogonal. Neither may be inferred from the other.
 
-## Gate 1: PR merge
+Two forbidden conclusions define the boundary:
 
-The PR merge gate answers one question: **is this repository revision safe to merge?**
+- **“The real machine/environment is unavailable, therefore this code cannot be merged.”** Forbidden. Missing target-environment evidence makes the relevant product/runtime criterion UNVERIFIED; it does not make repository acceptance fail.
+- **“CI is green, therefore the product is complete.”** Forbidden. CI proves repository acceptance criteria only; product completion requires direct product/runtime evidence.
+
+## Evidence model
+
+| evidence/state | valid conclusion | invalid conclusion |
+|---|---|---|
+| `check:merge` / green CI | revision satisfies repository merge criteria | product is complete, works on target, is releasable, or was released |
+| target machine/service unavailable | target-specific criterion remains UNVERIFIED | revision is unmergeable |
+| simulator/mock/contract test passes | deterministic repository boundary holds | target behavior actually occurred |
+| `release:check` passes | concrete artifact passes local release preflight | remote publication occurred |
+| target/runtime verification passes | tested product criterion holds on that target | unrelated repository criteria pass |
+| remote receipt/read-back passes | specified external postcondition occurred | source quality or mergeability |
+
+## Gate 1: repository merge acceptance
+
+The merge gate answers one question: **does this repository revision satisfy the source/repository contract?**
 
 Canonical commands:
 
@@ -13,7 +29,7 @@ task check:merge:fast
 task check:merge
 ```
 
-`check:merge:fast` checks only repository/source state:
+`check:merge:fast` checks repository/source state such as:
 
 - Biome formatting and lint
 - TypeScript type safety
@@ -23,23 +39,34 @@ task check:merge
 
 `check:merge` adds the Bun test suite under `SKIP_LLM=true DRY_RUN=true`.
 
-The merge gate must not depend on:
+### Environment-independence rule
 
+The merge gate must be reproducible in the supported development/CI environment. It must not require:
+
+- a particular production machine or device
 - production OAuth credentials
 - a specific `RUN_ID`
 - current YouTube remote state
 - historical `runs/` cleanup receipts
 - whether a concrete video is currently ready to publish
 
+Hardware/service-specific code must expose a deterministic merge-time boundary: typed interfaces, schema/contract tests, fixtures, mocks, emulators, simulators, static checks, or another reproducible substitute appropriate to the boundary.
+
+If a behavior can only be proven on the real target, that criterion belongs to product/runtime qualification. Until the target is available, mark it **UNVERIFIED**. Do not hold the PR unmergeable solely because the target environment cannot be exercised.
+
 GitHub Actions runs `bun run check:merge`. The pre-commit/pre-push hook runs `bun run check:merge:fast`.
 
 `task check` and `task check:fast` remain compatibility aliases, but new automation and documentation should use the explicit `check:merge*` names.
 
-## Gate 2: product release
+A passing merge gate proves repository acceptance for that exact commit and nothing more.
 
-The product release gate answers a different question: **is this concrete run/artifact allowed to cross the publication boundary?**
+## Gate 2: product qualification and release
 
-Canonical preflight:
+Product completion answers a different question: **do the product acceptance criteria have direct evidence in the environment where they are defined?**
+
+Green CI is never sufficient evidence for this verdict.
+
+For YT3 publication, the canonical local preflight is:
 
 ```bash
 task release:check PROFILE=byosan -- <run-id> [video-path]
@@ -52,15 +79,29 @@ The release gate is run-specific. It verifies:
 - explicit profile and exact profile-to-environment routing
 - run bucket matches the selected channel profile
 - run directory and canonical state exist
-- the selected video artifact exists and has a stable SHA-256 identity
+- selected video artifact exists and has a stable SHA-256 identity
 - fallback-labeled metadata is prohibited
 - canonical publication state does not point at a different artifact
 - unresolved `PRIVATE_UPLOAD_INTENT` / `UNCERTAIN_REMOTE_COMMIT` state without a verified video ID blocks another release
 - factual-integrity evidence passes when configured visibility is non-private
 
-`src/scripts/publish_youtube.ts` executes this gate before OAuth/channel verification or any YouTube publication step. Passing the local product release gate does **not** itself publish anything.
+Passing local release preflight does not establish product completion by itself when the product contract requires target/runtime checks beyond that preflight.
 
-After the local gate passes, the publication path still verifies the authenticated YouTube channel, stages upload state, reads back remote identity/visibility, applies requested visibility, and records publication evidence. Those remote checks are release conditions, not PR merge conditions.
+`src/scripts/publish_youtube.ts` executes the release gate before OAuth/channel verification or YouTube publication. After local preflight, the publication path still verifies authenticated channel identity, stages upload state, reads back remote identity/visibility, applies requested visibility, and records publication evidence.
+
+Those are product/release conditions, not PR merge conditions.
+
+## Product status must remain explicit
+
+Use separate states rather than one overloaded “done” flag:
+
+- **repository mergeable** — merge gate passed for the exact revision
+- **product criteria verified** — required product/runtime checks passed
+- **release-ready** — concrete artifact passed its release preflight
+- **released/externally applied** — remote side effect has a receipt/read-back
+- **UNVERIFIED** — required evidence could not be obtained
+
+Do not translate `UNVERIFIED` into failure outside the criterion it belongs to. Do not translate repository success into product success.
 
 ## Runtime policy audits are operational evidence
 
@@ -76,14 +117,15 @@ task audit:no-fallback
 
 ## Ownership matrix
 
-| concern | owner | merge gate | release gate |
+| concern | owner | merge gate | product/release |
 |---|---|---:|---:|
 | formatting + lint | Biome | yes | no |
 | TypeScript types | TypeScript compiler | yes | no |
 | executable/docs contract | repository audit | yes | no |
 | static channel routing | repository audit | yes | inherited invariant |
 | source no-fallback policy | repository audit | yes | inherited invariant |
-| unit/contract tests | Bun test | yes | no |
+| unit/contract/simulation tests | repository checks | yes | not target evidence |
+| target machine/runtime behavior | product qualification | no | yes when required |
 | concrete run state | product release gate | no | yes |
 | artifact identity | product release gate | no | yes |
 | factual-integrity evidence | product release gate | no | yes |
@@ -103,9 +145,13 @@ bun run check:merge
 
 `setup` uses `bun ci` with the committed `bun.lock`; dependency-resolution drift therefore fails rather than silently rewriting the dependency graph.
 
+A fresh clone must be capable of establishing mergeability without access to production hardware, production credentials, or a concrete release run.
+
 ## Boundary validation
 
-Zod remains the runtime boundary parser for untrusted API, artifact, configuration, and persisted-state inputs. New boundary work should parse once, then pass typed values inward. Release readiness is kept separate from merge readiness even when both reuse the same typed domain models.
+Zod remains the runtime boundary parser for untrusted API, artifact, configuration, and persisted-state inputs. New boundary work should parse once, then pass typed values inward.
+
+For hardware/service boundaries, prefer deterministic repository-level contracts plus separate target qualification. The deterministic substitute proves interface and logic behavior; target qualification proves actual target behavior. Neither substitutes for the other.
 
 ## Tool decisions
 
@@ -123,4 +169,8 @@ YT3 is not a genuine multi-project monorepo with an Nx task-graph requirement. A
 
 ## CI evidence
 
-For repository-change PRs, inspect the GitHub Actions result on the exact PR head SHA before merge. A passing merge gate proves repository acceptance criteria only; do not reinterpret it as proof that a concrete product run is releasable or published.
+For repository-change PRs, inspect the GitHub Actions result on the exact PR head SHA before merge.
+
+A passing CI run means **repository merge acceptance passed for that revision**. It must never be reported as “product complete”, “production verified”, “works on the real machine”, “release verified”, or equivalent unless those separate criteria were directly checked.
+
+Conversely, inability to access the target machine, production service, or release credentials must never be reported as a reason the repository cannot merge when the repository merge gate itself passes.


### PR DESCRIPTION
## Contract

Prohibit two invalid cross-gate conclusions:

- lack of a real target machine/environment must not by itself block repository merge acceptance;
- green CI must not be interpreted as product completion, production verification, or release evidence.

## Changes

- Define repository acceptance and product/runtime evidence as orthogonal verdicts in `AGENTS.md`.
- Require deterministic merge-time boundaries for hardware/service-specific code while leaving real-target behavior UNVERIFIED until qualified.
- Define explicit product states instead of overloading one `done` verdict.
- Align `docs/QUALITY_GATES.md` with the same evidence model and ownership matrix.

## Acceptance

- Documentation read-back matches the intended two-way prohibition.
- Merge gate remains independent of production hardware, credentials, concrete runs, and remote state.
- Product completion requires direct product/runtime evidence rather than CI inference.
- No product publication or external side effect is performed by this PR.