### PR TITLE
refactor: remove publish aliases and duplicate operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,76 +2,49 @@
 
 [![CI](https://github.com/KAFKA2306/yt3/actions/workflows/ci.yml/badge.svg)](https://github.com/KAFKA2306/yt3/actions/workflows/ci.yml)
 
-YT3 is a resumable media-production and YouTube-operations system. Its main concern is not merely generating a video; it is preserving enough state and evidence to answer what happened, what passed, where a run stopped, and which remote channel received an artifact.
-
-The canonical operator interface is `Taskfile.yml`.
+YT3 is a resumable media-production and YouTube-operations system. `Taskfile.yml` is the canonical operator interface; internal scripts are implementation details.
 
 ```bash
 task --list
 ```
 
-Internal TypeScript and shell files are implementation details. Human and agent operations should use an existing Taskfile task instead of creating a second execution path.
-
-## Operating model
+## Canonical flow
 
 ```text
 source / event
   -> research
   -> verified facts
   -> script
-  -> media production
-  -> deterministic/editorial audit
+  -> media
+  -> audit
   -> product release gate
-  -> channel-routing verification
+  -> channel verification
   -> private upload
   -> remote read-back
   -> requested visibility
-  -> publication receipt
-  -> analytics / improvement evidence
+  -> receipt / analytics evidence
 ```
 
-The core rules are:
+Core rules:
 
-- **Facts first.** Material claims retain provenance.
-- **Fail closed.** Missing evidence, routing ambiguity, verifier failure, or uncertain remote state does not become fallback success.
-- **One operator surface.** `Taskfile.yml` owns executable entry points.
-- **Channel identity is a hard boundary.** 秒算マネー, 夜話アーカイブ, and 人類観測所 must not be mixed.
-- **State is for resumption; evidence is for proof.** Generated artifacts and attestations do not become competing workflow states.
-- **Merge and release are different decisions.** Repository readiness does not imply that any concrete product run is releasable.
-- **Publication is a separate side effect.** A rendered file is not a YouTube receipt, and a receipt is not remote visibility verification.
+- Facts retain provenance.
+- Missing evidence, ambiguous routing, or uncertain remote state fails closed.
+- `Taskfile.yml` owns operator entry points.
+- `YOUTUBE_PROFILES` owns channel, bucket, env-file, and token routing.
+- State enables resumption; evidence proves what happened.
+- Repository merge, product release, and remote publication are separate decisions.
 
-## Setup and PR merge gate
-
-Install the exact dependency graph committed in `bun.lock`, then run the explicit PR merge gate:
+## Setup and repository gate
 
 ```bash
 task setup
 task check:merge
+task check:merge:fast   # deterministic preflight
 ```
 
-For a faster deterministic preflight:
+The repository gate checks source/repository state only: lint, types, repository contract, static publish routing, source no-fallback policy, and tests. It does not require production OAuth, a specific run, or live YouTube state.
 
-```bash
-task check:merge:fast
-```
-
-The merge gate checks repository/source state only: lint, types, repository contract, static publish routing, source-level no-fallback policy, and tests. It deliberately does **not** depend on production OAuth credentials, a specific `RUN_ID`, historical runtime receipts, or current YouTube state.
-
-Quality-gate ownership is documented in [docs/QUALITY_GATES.md](docs/QUALITY_GATES.md).
-
-## Product release gate
-
-A concrete run is checked separately before publication:
-
-```bash
-task release:check PROFILE=byosan -- <run-id> [video-path]
-task release:check PROFILE=yawa -- <run-id> [video-path]
-task release:check PROFILE=humanity -- <run-id> [video-path]
-```
-
-The product release gate verifies the selected profile/bucket, canonical run state, artifact existence and SHA-256 identity, no-fallback metadata, publication-state conflicts, and factual-integrity evidence when the configured visibility is non-private.
-
-Passing `release:check` does not publish anything. The canonical `publish` path runs the same product release gate before OAuth/channel verification or any YouTube publication step.
+See [docs/QUALITY_GATES.md](docs/QUALITY_GATES.md).
 
 ## Production
 
@@ -82,28 +55,25 @@ task byosan:daily
 task run:humanity
 ```
 
-Use explicit run IDs when resuming or publishing. Do not infer a publication target from an unrelated "latest" directory.
+Use explicit run IDs when resuming or publishing. Publication never infers an unrelated latest run.
 
-Useful status surfaces:
+## Release and publication
+
+Profiles are explicit:
+
+| profile | brand | bucket |
+|---|---|---|
+| `byosan` | 秒算マネー | `byosan_money` |
+| `yawa` | 夜話アーカイブ ASMR | `yawa_archive` |
+| `humanity` | 雨晴はうの人類観測所 | `humanity_observatory` |
+
+Check one exact run/artifact without publishing:
 
 ```bash
-task audit:today
-task daily:last3
-task daily:guarantee-status
-task movie:status
-task audit:publish-routing
-task publish:visibility-audit
+task release:check PROFILE=byosan -- <run-id> [video-path]
 ```
 
-## Channel profiles and publication
-
-| profile | brand | bucket | production / publication |
-|---|---|---|---|
-| `byosan` | 秒算マネー | `byosan_money` | `task byosan:daily` / `task publish:byosan` |
-| `yawa` | 夜話アーカイブ ASMR | `yawa_archive` | `task asmr:publish` / `task publish:yawa` |
-| `humanity` | 雨晴はうの人類観測所 | `humanity_observatory` | `task run:humanity` / `task publish:humanity` |
-
-Generic publication requires an explicit profile:
+Publish through the single canonical command:
 
 ```bash
 task publish PROFILE=byosan -- <run-id> [video-path]
@@ -111,83 +81,40 @@ task publish PROFILE=yawa -- <run-id> [video-path]
 task publish PROFILE=humanity -- <run-id> [video-path]
 ```
 
-Unknown profiles fail closed. Before upload, YT3 executes the product release gate and then verifies the intended profile against the authenticated YouTube channel. If a prior upload intent has uncertain remote commit state, the publisher stops rather than issuing another upload blindly.
+OAuth uses the same profile registry:
 
-## Publication state
+```bash
+task auth PROFILE=byosan
+task auth PROFILE=yawa
+task auth PROFILE=humanity
+```
 
-Do not compress these stages into one `done` flag:
+Unknown profiles fail closed. Before any YouTube side effect, publication runs the product release gate and verifies the authenticated channel against the selected profile. An unresolved remote upload intent blocks another upload.
+
+## Publication evidence
+
+`runs/<domain>/<run>/publish/state.json` is the canonical publication state. Receipts and attestations are evidence attached to it, not competing state machines.
+
+Important evidence paths:
 
 ```text
-SCRIPT_DONE
-MEDIA_GENERATED
-AUDIT_PASSED
-PRODUCT_RELEASE_GATE_PASS
-ROUTING_VERIFIED
-PRIVATE_UPLOADED
-REMOTE_VERIFIED
-VISIBILITY_APPLIED
-VISIBILITY_VERIFIED
+runs/<domain>/<run>/state.json
+runs/<domain>/<run>/audit/
+runs/<domain>/<run>/publish/state.json
+runs/<domain>/<run>/publish/*.json
+runs/<domain>/<run>/run_evidence.json
+db/
 ```
 
-`runs/<domain>/<run>/publish/state.json` is the canonical publication state. Thumbnail, caption, factual-integrity, visibility attestations, and `receipt.json` are evidence attached to that state rather than independent state machines.
+A generated media file is not proof of publication. A local receipt is not proof of current remote visibility.
 
-## No-fallback scopes
-
-Source policy and runtime cleanup are separate concerns:
-
-```bash
-task audit:no-fallback:source
-task audit:no-fallback:runtime
-task audit:no-fallback
-```
-
-Only the source scope belongs to the PR merge gate. Historical runtime deletion evidence remains an operational audit and cannot block an unrelated code change from merging.
-
-## Evidence layout
-
-```text
-runs/<domain>/<run>/state.json             production state
-runs/<domain>/<run>/audit/                 audit results and raw evidence
-runs/<domain>/<run>/publish/state.json     canonical publication state
-runs/<domain>/<run>/publish/*.json         release/publication attestations and receipt
-runs/<domain>/<run>/run_evidence.json      cross-stage run evidence
-db/                                        cross-run evolution/audit data
-docs/                                      maintained standards and ADRs
-```
-
-The system audit protocol is [docs/standard/system-audit-protocol.md](docs/standard/system-audit-protocol.md). Humanity Observatory has a separate domain standard at [docs/standard/humanity-observatory-audit-standard.md](docs/standard/humanity-observatory-audit-standard.md).
-
-## Operational entry points
-
-Production:
-
-```bash
-task loop
-task run
-task run:humanity
-task byosan:daily
-```
-
-Release and publication:
-
-```bash
-task release:check PROFILE=byosan -- <run-id>
-task publish:byosan -- <run-id>
-task publish:yawa -- <run-id>
-task publish:humanity -- <run-id>
-task asmr:publish
-```
-
-Audit and status:
+## Audit and status
 
 ```bash
 task audit:today
 task audit:publish-routing
 task audit:byosan-money
 task audit:no-fallback:source
-task audit:no-fallback:runtime
-task audit:no-fallback
-task audit:repo-contract
 task publish:visibility-audit
 task daily:guarantee-status
 task daily:last3
@@ -195,45 +122,47 @@ task daily:report
 task improve:report
 ```
 
-Local services:
+Historical runtime cleanup is separate from the PR merge gate:
 
 ```bash
+task audit:no-fallback:runtime
+task audit:no-fallback
+```
+
+## Other operator surfaces
+
+```bash
+task movie:generate PLAN=<plan.json>
+task movie:status
+task analytics:refresh
+task asmr:ops
+task asmr:publish
 task bootstrap
 task up
 task down
+task serve
 ```
 
-Local service availability is environment-dependent; documentation is not evidence that a service is running.
+Local service availability is environment-dependent; documentation is not runtime evidence.
 
 ## Repository map
 
 ```text
-src/          production, audit, release, publish, and workflow implementation
-config/       channel, environment, and domain configuration
+src/          workflow, audit, release, publish, and operations
+config/       domain and channel configuration
 runs/         runtime state and evidence
 audits/       repository-level verification evidence
 artifacts/    generated/supporting artifacts
-db/           cross-run evolution and audit data
+db/           cross-run data
 docs/         maintained standards and ADRs
-asmr/         ASMR workflow and archive tooling
+asmr/         ASMR workflow tooling
 Taskfile.yml  canonical operator interface
-AGENTS.md     repository execution contract for agents
-GEMINI.md     runtime epistemic contract
 bun.lock      reproducible dependency graph
 ```
 
+System audit protocol: [docs/standard/system-audit-protocol.md](docs/standard/system-audit-protocol.md).  
+Humanity Observatory standard: [docs/standard/humanity-observatory-audit-standard.md](docs/standard/humanity-observatory-audit-standard.md).
+
 ## Completion boundary
 
-A merged PR proves repository acceptance only. A passed product release gate proves local release readiness only. Publication is verified only after remote receipt/read-back evidence exists.
-
-For any run, the operator should be able to answer:
-
-- What facts were used?
-- Which artifacts were generated?
-- Which checks passed or blocked progression?
-- Did the PR merge gate pass for the code revision?
-- Did the product release gate pass for this exact run/artifact?
-- Which channel was intended and authenticated?
-- Was a remote video already created?
-- What is its current visibility?
-- From which exact state should the next execution resume?
+A merged PR proves repository acceptance only. A passed product release gate proves local release readiness only. Publication is complete only when remote receipt/read-back evidence verifies the intended channel and visibility.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,18 +34,6 @@ tasks:
     desc: "Publish to YouTube after the product release gate (PROFILE=byosan|yawa|humanity; required)"
     cmds: ["YOUTUBE_CHANNEL_PROFILE={{.PROFILE}} bun src/scripts/publish_youtube.ts {{.CLI_ARGS}}"]
 
-  publish:byosan:
-    desc: "Publish to 秒算マネー"
-    cmds: ["task publish PROFILE=byosan -- {{.CLI_ARGS}}"]
-
-  publish:yawa:
-    desc: "Publish to 夜話アーカイブ"
-    cmds: ["task publish PROFILE=yawa -- {{.CLI_ARGS}}"]
-
-  publish:humanity:
-    desc: "Publish to 人類観測所"
-    cmds: ["task publish PROFILE=humanity -- {{.CLI_ARGS}}"]
-
   auth:
     desc: "YouTube OAuth (PROFILE=byosan|yawa|humanity; required)"
     cmds: ["YOUTUBE_CHANNEL_PROFILE={{.PROFILE}} bun src/scripts/youtube_oauth.ts {{.CLI_ARGS}}"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-This directory contains the maintained operational standards and architecture decisions for YT3. Runtime state and generated evidence belong under `runs/`, `audits/`, `artifacts/`, and `logs/`; this index links only to version-controlled documentation.
+This directory contains maintained operational standards and architecture decisions for YT3. Runtime state and generated evidence belong under `runs/`, `audits/`, `artifacts/`, and `logs/`.
 
 ## Operations
 
@@ -19,14 +19,12 @@ This directory contains the maintained operational standards and architecture de
 
 ## Publication
 
-Use an explicit run ID. The safe channel-specific entry points delegate to the same publisher:
+Use an explicit profile and run ID through the single publisher:
 
 ```bash
-task publish:byosan -- <run-id>
-task publish:yawa -- <run-id>
-task publish:humanity -- <run-id>
 task publish PROFILE=byosan -- <run-id>
-task movie:status
+task publish PROFILE=yawa -- <run-id>
+task publish PROFILE=humanity -- <run-id>
 ```
 
 There is no latest-run inference path.

--- a/src/scripts/audit_publish_routing.ts
+++ b/src/scripts/audit_publish_routing.ts
@@ -14,12 +14,6 @@ const PROFILE_TASKS = {
 	auth: "bun src/scripts/youtube_oauth.ts",
 } as const;
 
-const PUBLISH_ALIASES: Record<string, YouTubeProfileName> = {
-	"publish:byosan": "byosan",
-	"publish:yawa": "yawa",
-	"publish:humanity": "humanity",
-};
-
 function flattenCmds(cmds: unknown): string[] {
 	if (typeof cmds === "string") return [cmds];
 	if (!Array.isArray(cmds)) return [];
@@ -107,18 +101,6 @@ function assertProfileTasks(tasks: Record<string, TaskDefinition>) {
 	}
 }
 
-function assertPublishAliases(tasks: Record<string, TaskDefinition>) {
-	for (const [taskName, profile] of Object.entries(PUBLISH_ALIASES)) {
-		const command = singleCommand(taskName, tasks[taskName]);
-		const expected = `task publish PROFILE=${profile} -- {{.CLI_ARGS}}`;
-		if (command !== expected) {
-			throw new Error(
-				`Alias ${taskName} must be '${expected}', got '${command}'`,
-			);
-		}
-	}
-}
-
 async function main() {
 	assertProfileRegistry();
 	const taskfile = yaml.load(
@@ -126,7 +108,6 @@ async function main() {
 	) as { tasks?: Record<string, TaskDefinition> };
 	if (!taskfile.tasks) throw new Error("Taskfile.yml has no tasks section");
 	assertProfileTasks(taskfile.tasks);
-	assertPublishAliases(taskfile.tasks);
 	console.log("publish routing audit: PASS");
 }
 


### PR DESCRIPTION
## Summary
- remove `publish:byosan`, `publish:yawa`, and `publish:humanity` aliases
- keep `task publish PROFILE=...` as the only publication entrypoint
- remove alias-specific routing audit code
- compress README/operator docs around the canonical workflow and evidence boundaries

## Result
Fewer operator entrypoints, less audit code, and one publication command without changing release or channel safety.

## Validation
Run the exact-head repository merge gate before merge.