### PR TITLE
refactor: simplify production entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,6 @@ task audit:publish-routing
 task audit:no-fallback SCOPE=source
 task audit:no-fallback SCOPE=runtime
 task audit:today
-task daily:last3
 task daily:guarantee-status
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ See [docs/QUALITY_GATES.md](docs/QUALITY_GATES.md).
 
 ```bash
 task loop
-task run
+task run                       # 秒算マネー by default
+PROFILE=humanity task run      # 人類観測所
 task byosan:daily
-task run:humanity
 ```
+
+`task run` resolves the workflow bucket and environment from `YOUTUBE_PROFILES`; it does not maintain a second profile-to-config mapping. 夜話アーカイブ uses the ASMR operator path rather than `src/index.ts`.
 
 Use explicit run IDs when resuming or publishing. Publication never infers an unrelated latest run.
 
@@ -99,7 +101,6 @@ task audit:no-fallback SCOPE=runtime
 task audit:no-fallback
 task publish:visibility-audit
 task daily:guarantee-status
-task daily:last3
 task daily:report
 task improve:report
 ```
@@ -114,7 +115,6 @@ task movie:status
 task analytics:refresh
 task asmr:ops
 task asmr:publish
-task bootstrap
 task up
 task down
 task serve

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,12 +14,8 @@ tasks:
     cmds: ["bun src/scripts/agentic_orchestrator.ts"]
 
   run:
-    desc: "Run the full workflow"
-    cmds: ["bun --env-file=config/.env src/index.ts {{.CLI_ARGS}}"]
-
-  run:humanity:
-    desc: "Run the Humanity Observatory workflow"
-    cmds: ["ENV_FILE=config/.env YOUTUBE_CHANNEL_PROFILE=humanity BUCKET=humanity_observatory bun --env-file=config/.env src/index.ts {{.CLI_ARGS}}"]
+    desc: "Run the canonical workflow (PROFILE=byosan|humanity; default byosan)"
+    cmds: ["YOUTUBE_CHANNEL_PROFILE=${PROFILE:-byosan} bun src/index.ts {{.CLI_ARGS}}"]
 
   byosan:daily:
     desc: "Research, produce, audit, and publish one 秒算マネー feature"
@@ -95,12 +91,6 @@ tasks:
     desc: "Start the dashboard and API server"
     cmds: ["bun src/server.ts"]
 
-  bootstrap:
-    desc: "Install dependencies and start services"
-    cmds:
-      - task setup
-      - task up
-
   asr:
     desc: "Transcribe audio (FILE=... OUT=...)"
     cmds:
@@ -158,10 +148,6 @@ tasks:
   daily:guarantee-status:
     desc: "Generate the daily guarantee status artifact"
     cmds: ["bun src/scripts/daily_guarantee_status.ts"]
-
-  daily:last3:
-    desc: "Show the latest three daily runs"
-    cmds: ["DAILY_LAST3=1 bun src/scripts/daily_guarantee_status.ts"]
 
   daily:report:
     desc: "Regenerate daily audit and stability artifacts"

--- a/docs/adr/0030-humanity-observatory-v1.md
+++ b/docs/adr/0030-humanity-observatory-v1.md
@@ -32,7 +32,7 @@
 ### 5. 実行インフラ：Standardized Runtime
 - `src/humanity_observatory_workflow.ts` による専用ランタイム。
 - `data/humanity_pulse.md` をシードとした自律生成。
-- `task run:humanity` によるワンコマンド実行。
+- `PROFILE=humanity task run` で canonical production entrypoint を共有する。
 
 ## 帰結
 - 思想と実装が完全に同期され、レガシーな仮称（思考断面・認知ノイズ倶楽部）を排除した。

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ function resolveRunId(bucket: string): string {
 }
 
 async function main() {
-	const requestedProfile = process.env.YOUTUBE_CHANNEL_PROFILE?.trim() || "byosan";
+	const requestedProfile =
+		process.env.YOUTUBE_CHANNEL_PROFILE?.trim() || "byosan";
 	if (requestedProfile === "yawa") {
 		throw new Error("PROFILE=yawa uses the ASMR workflow, not src/index.ts");
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import fs from "fs-extra";
+import { loadYouTubeProfileEnv } from "./domain/youtube_profiles.js";
 import {
 	type AgentState,
 	AssetStore,
@@ -21,14 +22,19 @@ function resolveRunId(bucket: string): string {
 	const [domain, name, ...rest] = raw.split("/");
 	if (domain !== bucket || !name || rest.length > 0) {
 		throw new Error(
-			`Domain mismatch: BUCKET is '${bucket}' but RUN_ID is '${raw}'`,
+			`Domain mismatch: profile bucket is '${bucket}' but RUN_ID is '${raw}'`,
 		);
 	}
 	return raw;
 }
 
 async function main() {
-	const bucket = process.env.BUCKET?.trim() || "byosan_money";
+	const requestedProfile = process.env.YOUTUBE_CHANNEL_PROFILE?.trim() || "byosan";
+	if (requestedProfile === "yawa") {
+		throw new Error("PROFILE=yawa uses the ASMR workflow, not src/index.ts");
+	}
+	const profile = loadYouTubeProfileEnv(requestedProfile);
+	const bucket = profile.bucket;
 	loadConfig(bucket);
 	const runId = resolveRunId(bucket);
 	const store = new AssetStore(runId);

--- a/src/scripts/agentic_orchestrator.ts
+++ b/src/scripts/agentic_orchestrator.ts
@@ -4,12 +4,15 @@ import fs from "fs-extra";
 import { sendAlert } from "../io/utils/discord.js";
 import { AgentLogger } from "../io/utils/logger.js";
 
-async function runTask(taskName: string): Promise<boolean> {
+async function runTask(
+	taskName: string,
+	env: NodeJS.ProcessEnv = {},
+): Promise<boolean> {
 	AgentLogger.info("SYSTEM", "LOOP", "TASK_START", `Running task: ${taskName}`);
 	return new Promise((resolve) => {
 		const proc = spawn("task", [taskName], {
 			stdio: "inherit",
-			env: { ...process.env, FORCE_COLOR: "1" },
+			env: { ...process.env, ...env, FORCE_COLOR: "1" },
 		});
 		proc.on("close", (code) => {
 			const ok = code === 0;
@@ -42,9 +45,9 @@ function auditPassed(): boolean {
 async function main() {
 	AgentLogger.init();
 	const results = new Map<string, boolean>();
-	for (const taskName of ["byosan:daily", "run:humanity", "audit:today"]) {
-		results.set(taskName, await runTask(taskName));
-	}
+	results.set("byosan:daily", await runTask("byosan:daily"));
+	results.set("run[humanity]", await runTask("run", { PROFILE: "humanity" }));
+	results.set("audit:today", await runTask("audit:today"));
 
 	const failures = [...results]
 		.filter(([, ok]) => !ok)


### PR DESCRIPTION
## Summary
- collapse `run` and `run:humanity` into one canonical `task run`
- resolve workflow profile, env file, and bucket from `YOUTUBE_PROFILES` inside `src/index.ts`
- keep `yawa` on the ASMR operator path instead of the generic workflow
- remove the thin `bootstrap` and `daily:last3` aliases
- update loop orchestration and maintained docs to the single entrypoint

## Validation
Run the exact-head repository merge gate before merge. The repository-contract audit should reject stale documented Taskfile commands.