### PR TITLE
Connect Power Macro history to Byosan research runtime

### DIFF
--- a/src/domain/agents/research.ts
+++ b/src/domain/agents/research.ts
@@ -18,6 +18,7 @@ import {
 	loadRecentByosanTitles,
 	selectByosanAngle,
 } from "../byosan/news_angle.js";
+import { composeResearchMemoryContext } from "../byosan/power_macro_memory.js";
 import { type NewsItem, NewsItemSchema } from "../types.js";
 
 export interface ResearchResult {
@@ -53,6 +54,7 @@ export class TrendScout extends BaseAgent {
 			limit: limit || researchCfg.default_limit || 3,
 		});
 		const recent = loadMemoryContext(this.store);
+		const memoryContext = composeResearchMemoryContext(bucket, recent, ROOT);
 		const promptCfg = this.loadPrompt<{
 			consolidated_research: { system: string; user_template: string };
 		}>(this.name);
@@ -63,7 +65,7 @@ export class TrendScout extends BaseAgent {
 				"{regions}",
 				researchCfg.regions.map((region) => region.lang).join(", "),
 			)
-			.replace("{recent_topics}", recent)
+			.replace("{recent_topics}", memoryContext)
 			.replace("{recent_themes}", recentThemes)
 			.replace("{current_date}", currentDate);
 		userPrompt += this.buildSourceRegistryPrompt(bucket);
@@ -203,7 +205,7 @@ export class TrendScout extends BaseAgent {
 				.flatMap((topic) => topic.results)
 				.flatMap((item) => item.news)
 				.filter((item) => item?.title),
-			memory_context: recent,
+			memory_context: memoryContext,
 			angle_decision: angleDecision,
 		};
 		this.logOutput(result);

--- a/src/domain/byosan/power_macro_memory.ts
+++ b/src/domain/byosan/power_macro_memory.ts
@@ -1,0 +1,153 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { ROOT } from "../../io/core.js";
+
+export interface PowerMacroWeek {
+	week_end: string;
+	regime: string;
+	new_insights: string[];
+	thesis_update: string;
+	counterevidence: string;
+	source_report: string;
+}
+
+interface PersistentThesis {
+	id: string;
+	statement: string;
+	status: string;
+}
+
+interface PowerMacroHistory {
+	schema_version: number;
+	domain: string;
+	kind: string;
+	derived_from: {
+		repository: string;
+		report_series: string;
+		period_start: string;
+		period_end: string;
+		note?: string;
+	};
+	weeks: PowerMacroWeek[];
+	persistent_theses: PersistentThesis[];
+}
+
+export function getByosanPowerMacroHistoryPath(root = ROOT): string {
+	return path.join(
+		root,
+		"data",
+		"memory",
+		"byosan_money",
+		"power_macro_history.json",
+	);
+}
+
+function assertWeek(week: PowerMacroWeek): void {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(week.week_end)) {
+		throw new Error(`BYOSAN_POWER_MACRO_INVALID_WEEK_END: ${week.week_end}`);
+	}
+	for (const [key, value] of Object.entries({
+		regime: week.regime,
+		thesis_update: week.thesis_update,
+		counterevidence: week.counterevidence,
+		source_report: week.source_report,
+	})) {
+		if (typeof value !== "string" || value.trim().length === 0) {
+			throw new Error(`BYOSAN_POWER_MACRO_INVALID_${key.toUpperCase()}`);
+		}
+	}
+	if (!Array.isArray(week.new_insights) || week.new_insights.length === 0) {
+		throw new Error("BYOSAN_POWER_MACRO_INVALID_NEW_INSIGHTS");
+	}
+	if (!week.source_report.startsWith("https://github.com/KAFKA2306/prompt-vault/")) {
+		throw new Error("BYOSAN_POWER_MACRO_INVALID_SOURCE_REPORT");
+	}
+}
+
+function readHistory(root = ROOT): PowerMacroHistory {
+	const file = getByosanPowerMacroHistoryPath(root);
+	if (!fs.existsSync(file)) {
+		throw new Error(`BYOSAN_POWER_MACRO_HISTORY_MISSING: ${file}`);
+	}
+	const history = fs.readJsonSync(file) as PowerMacroHistory;
+	if (
+		history.schema_version !== 1 ||
+		history.domain !== "byosan_money" ||
+		history.kind !== "power_macro_weekly_history" ||
+		!Array.isArray(history.weeks) ||
+		!Array.isArray(history.persistent_theses)
+	) {
+		throw new Error("BYOSAN_POWER_MACRO_HISTORY_INVALID_SCHEMA");
+	}
+	const seen = new Set<string>();
+	for (const week of history.weeks) {
+		assertWeek(week);
+		if (seen.has(week.week_end)) {
+			throw new Error(`BYOSAN_POWER_MACRO_DUPLICATE_WEEK: ${week.week_end}`);
+		}
+		seen.add(week.week_end);
+	}
+	for (const thesis of history.persistent_theses) {
+		if (!thesis.id || !thesis.statement || !thesis.status) {
+			throw new Error("BYOSAN_POWER_MACRO_INVALID_PERSISTENT_THESIS");
+		}
+	}
+	return history;
+}
+
+export function loadByosanPowerMacroContext(root = ROOT): string {
+	const history = readHistory(root);
+	const thesisText = history.persistent_theses
+		.map(
+			(thesis) =>
+				`【Thesis ${thesis.id} / ${thesis.status}】\n${thesis.statement}`,
+		)
+		.join("\n\n");
+	const recentWeekText = history.weeks
+		.slice(-3)
+		.reverse()
+		.map(
+			(week) =>
+				`【Week ${week.week_end}】\nRegime: ${week.regime}\nThesis update: ${week.thesis_update}\nCounterevidence: ${week.counterevidence}\nProvenance: ${week.source_report}`,
+		)
+		.join("\n\n");
+	return [
+		"[BYOSAN POWER MACRO LONG-TERM MEMORY]",
+		"Historical theses only. Use them to formulate questions and counterfactuals; do not treat them as current facts. Re-verify current claims with the approved source registry.",
+		thesisText,
+		recentWeekText,
+	]
+		.filter(Boolean)
+		.join("\n\n");
+}
+
+export function composeResearchMemoryContext(
+	bucket: string,
+	recentContext: string,
+	root = ROOT,
+): string {
+	if (bucket !== "byosan_money") return recentContext;
+	return [loadByosanPowerMacroContext(root), recentContext]
+		.filter(Boolean)
+		.join("\n\n");
+}
+
+export function appendByosanPowerMacroWeek(
+	week: PowerMacroWeek,
+	root = ROOT,
+): void {
+	assertWeek(week);
+	const history = readHistory(root);
+	if (history.weeks.some((existing) => existing.week_end === week.week_end)) {
+		throw new Error(`BYOSAN_POWER_MACRO_DUPLICATE_WEEK: ${week.week_end}`);
+	}
+	const latest = history.weeks.at(-1)?.week_end;
+	if (latest && week.week_end <= latest) {
+		throw new Error(
+			`BYOSAN_POWER_MACRO_NOT_APPEND_ONLY: latest=${latest} incoming=${week.week_end}`,
+		);
+	}
+	history.weeks.push(week);
+	history.derived_from.period_end = week.week_end;
+	fs.writeJsonSync(getByosanPowerMacroHistoryPath(root), history, { spaces: 2 });
+}

--- a/src/domain/byosan/power_macro_memory.ts
+++ b/src/domain/byosan/power_macro_memory.ts
@@ -59,7 +59,9 @@ function assertWeek(week: PowerMacroWeek): void {
 	if (!Array.isArray(week.new_insights) || week.new_insights.length === 0) {
 		throw new Error("BYOSAN_POWER_MACRO_INVALID_NEW_INSIGHTS");
 	}
-	if (!week.source_report.startsWith("https://github.com/KAFKA2306/prompt-vault/")) {
+	if (
+		!week.source_report.startsWith("https://github.com/KAFKA2306/prompt-vault/")
+	) {
 		throw new Error("BYOSAN_POWER_MACRO_INVALID_SOURCE_REPORT");
 	}
 }
@@ -149,5 +151,7 @@ export function appendByosanPowerMacroWeek(
 	}
 	history.weeks.push(week);
 	history.derived_from.period_end = week.week_end;
-	fs.writeJsonSync(getByosanPowerMacroHistoryPath(root), history, { spaces: 2 });
+	fs.writeJsonSync(getByosanPowerMacroHistoryPath(root), history, {
+		spaces: 2,
+	});
 }

--- a/tests/byosan_power_macro_memory.test.ts
+++ b/tests/byosan_power_macro_memory.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
+import {
+	appendByosanPowerMacroWeek,
+	composeResearchMemoryContext,
+	getByosanPowerMacroHistoryPath,
+	loadByosanPowerMacroContext,
+} from "../src/domain/byosan/power_macro_memory.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+async function copyHistoryToTemp(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "byosan-macro-memory-"));
+	tempRoots.push(root);
+	const destination = getByosanPowerMacroHistoryPath(root);
+	await fs.ensureDir(path.dirname(destination));
+	await fs.copy(
+		getByosanPowerMacroHistoryPath(process.cwd()),
+		destination,
+	);
+	return root;
+}
+
+describe("Byosan Power Macro runtime memory", () => {
+	test("projects five persistent theses and only the latest three weeks", () => {
+		const context = loadByosanPowerMacroContext(process.cwd());
+		expect(context.match(/【Thesis /g)?.length).toBe(5);
+		expect(context.match(/【Week /g)?.length).toBe(3);
+		expect(context).toContain("【Week 2026-07-04】");
+		expect(context).toContain("【Week 2026-06-27】");
+		expect(context).toContain("【Week 2026-06-20】");
+		expect(context).not.toContain("【Week 2026-06-13】");
+		expect(context).toContain("us_equity_eps_base");
+		expect(context).toContain("do not treat them as current facts");
+	});
+
+	test("adds long-term memory only to the byosan_money research context", () => {
+		const recent = "RECENT MEMORY";
+		const byosan = composeResearchMemoryContext(
+			"byosan_money",
+			recent,
+			process.cwd(),
+		);
+		expect(byosan).toContain("[BYOSAN POWER MACRO LONG-TERM MEMORY]");
+		expect(byosan).toContain(recent);
+		expect(
+			composeResearchMemoryContext("humanity_observatory", recent, process.cwd()),
+		).toBe(recent);
+	});
+
+	test("rejects a duplicate week_end", async () => {
+		const root = await copyHistoryToTemp();
+		expect(() =>
+			appendByosanPowerMacroWeek(
+				{
+					week_end: "2026-07-04",
+					regime: "duplicate",
+					new_insights: ["duplicate"],
+					thesis_update: "duplicate",
+					counterevidence: "duplicate",
+					source_report:
+						"https://github.com/KAFKA2306/prompt-vault/blob/main/docs/reports/weekly-power-macro-intelligence/2026-07-04.md",
+				},
+				root,
+			),
+		).toThrow("BYOSAN_POWER_MACRO_DUPLICATE_WEEK");
+	});
+
+	test("appends one future week and updates period_end", async () => {
+		const root = await copyHistoryToTemp();
+		appendByosanPowerMacroWeek(
+			{
+				week_end: "2026-07-11",
+				regime: "test regime",
+				new_insights: ["test insight"],
+				thesis_update: "test thesis update",
+				counterevidence: "test counterevidence",
+				source_report:
+					"https://github.com/KAFKA2306/prompt-vault/blob/main/docs/reports/weekly-power-macro-intelligence/2026-07-11.md",
+			},
+			root,
+		);
+		const updated = (await fs.readJson(getByosanPowerMacroHistoryPath(root))) as {
+			weeks: Array<{ week_end: string }>;
+			derived_from: { period_end: string };
+		};
+		expect(updated.weeks).toHaveLength(15);
+		expect(updated.weeks.at(-1)?.week_end).toBe("2026-07-11");
+		expect(updated.derived_from.period_end).toBe("2026-07-11");
+	});
+});

--- a/tests/byosan_power_macro_memory.test.ts
+++ b/tests/byosan_power_macro_memory.test.ts
@@ -20,10 +20,7 @@ async function copyHistoryToTemp(): Promise<string> {
 	tempRoots.push(root);
 	const destination = getByosanPowerMacroHistoryPath(root);
 	await fs.ensureDir(path.dirname(destination));
-	await fs.copy(
-		getByosanPowerMacroHistoryPath(process.cwd()),
-		destination,
-	);
+	await fs.copy(getByosanPowerMacroHistoryPath(process.cwd()), destination);
 	return root;
 }
 
@@ -50,7 +47,11 @@ describe("Byosan Power Macro runtime memory", () => {
 		expect(byosan).toContain("[BYOSAN POWER MACRO LONG-TERM MEMORY]");
 		expect(byosan).toContain(recent);
 		expect(
-			composeResearchMemoryContext("humanity_observatory", recent, process.cwd()),
+			composeResearchMemoryContext(
+				"humanity_observatory",
+				recent,
+				process.cwd(),
+			),
 		).toBe(recent);
 	});
 
@@ -86,7 +87,9 @@ describe("Byosan Power Macro runtime memory", () => {
 			},
 			root,
 		);
-		const updated = (await fs.readJson(getByosanPowerMacroHistoryPath(root))) as {
+		const updated = (await fs.readJson(
+			getByosanPowerMacroHistoryPath(root),
+		)) as {
 			weeks: Array<{ week_end: string }>;
 			derived_from: { period_end: string };
 		};


### PR DESCRIPTION
Closes #62

## What changed
- add `src/domain/byosan/power_macro_memory.ts` as the single read/write adapter for `power_macro_history.json`
- project all persistent theses plus only the latest 3 weekly changes into research context
- mark historical theses as historical context, not current evidence
- connect the projection to `TrendScout` only for `byosan_money`
- keep other domains on the existing recent-memory behavior
- reject duplicate/out-of-order weekly appends and advance `derived_from.period_end`
- add focused regression tests for projection, domain isolation, duplicate rejection, and append semantics

## Runtime contract
Prompt Vault remains provenance. `power_macro_history.json` remains the long-lived compressed authority. `essences.json` and `loop_journal.json` behavior is unchanged.

## Verification
Merge only after exact-head CI succeeds.