### PR TITLE
Add publish-ready Byosan preparation task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,20 @@ tasks:
     cmds:
       - ENV_FILE=config/.env.byosan YOUTUBE_CHANNEL_PROFILE=byosan bun --env-file=config/.env.byosan src/scripts/byosan_daily.ts {{.CLI_ARGS}}
 
+  byosan:prepare:
+    desc: "Prepare one 秒算マネー run through the product release gate without publishing (DATE=YYYY-MM-DD required)"
+    cmds:
+      - |
+        if ! printf '%s' "{{.DATE}}" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+          echo "DATE=YYYY-MM-DD is required" >&2
+          exit 2
+        fi
+      - BYOSAN_DATE={{.DATE}} BYOSAN_DAILY_NO_PUBLISH=true task byosan:daily
+      - task release:check PROFILE=byosan -- byosan_money/{{.DATE}}-daily
+      - |
+        echo "PUBLISH_READY_RUN=byosan_money/{{.DATE}}-daily"
+        echo "PUBLISH_COMMAND=task publish PROFILE=byosan -- byosan_money/{{.DATE}}-daily"
+
   release:check:
     desc: "Check run-specific product release conditions without external publication (PROFILE required)"
     cmds: ["YOUTUBE_CHANNEL_PROFILE={{.PROFILE}} bun src/scripts/check_product_release.ts {{.CLI_ARGS}}"]


### PR DESCRIPTION
Closes #65

## What changed
- add one canonical Taskfile entry point: `task byosan:prepare DATE=YYYY-MM-DD`
- require an explicit date instead of inferring today
- compose existing `byosan:daily` with `BYOSAN_DAILY_NO_PUBLISH=true`
- run the existing product `release:check`
- only after that gate passes, print the exact run id and final `task publish PROFILE=byosan -- <run-id>` command
- add no new state store, handoff file, fallback path, or publication implementation

## Safety boundary
`byosan:prepare` never performs the external publication step. The irreversible publish path remains the existing explicit `task publish` command.

## Local-agent handoff
After merge, the local agent should run:

```bash
task setup
task byosan:prepare DATE=2026-08-30
```

Then record the release-gate SHA-256 plus `PUBLISH_READY_RUN` / `PUBLISH_COMMAND` in #65 and stop without publishing.

## Verification
Merge only after exact-head CI succeeds.