### PR TITLE
Document target-host production execution contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,31 +67,17 @@ task stability:report
 
 Internal `src/scripts/*` and package scripts support Taskfile/CI; they are not a second human-facing interface unless explicitly documented as one.
 
-### Production execution is a target-host operation
+### Production execution requests are runtime operations
 
-An explicit request to run/start/`動かす` production means executing the canonical production task on the target runtime. Repository validation, CI, tests, mocks, or `DRY_RUN` are not substitutes for that request.
+An explicit request to run/start/`動かす` a production path is not satisfied by repository validation alone. It means executing the canonical Taskfile command on the target runtime.
 
-For 秒算マネー, use only these Taskfile entry points:
-
-```bash
-# Prepare and pass the local product release gate without publishing.
-task byosan:prepare DATE=YYYY-MM-DD
-
-# Full daily production path, including publication when its gates permit it.
-task byosan:daily
-
-# Explicit publication of an already prepared run.
-task publish PROFILE=byosan -- byosan_money/YYYY-MM-DD-daily
-```
-
-Rules:
-
-- run production commands on the target host that owns the required `config/.env.byosan`, OAuth credentials, media/runtime dependencies, and local services;
-- if authorized target-host execution capability is available, use it instead of stopping at repository or CI evidence;
-- never reinterpret a requested production run as “run CI” or “verify the code”;
+- if authorized target-host execution capability is available, use it rather than stopping at CI or repository evidence;
+- CI, unit tests, mocks, simulations, and `DRY_RUN` must never be reported as the requested production execution;
 - never create an ad-hoc GitHub Actions workflow merely to bypass the target-host boundary;
-- if the current tool context cannot execute on the target host, report the runtime result as **UNVERIFIED** and state that the production command was not executed;
+- if the current tool context cannot execute on the target host, report the runtime result as **UNVERIFIED** and explicitly state that the production command was not executed;
 - repository acceptance may be VERIFIED while product/runtime/publication remains separately UNVERIFIED.
+
+For 秒算マネー, `task byosan:prepare DATE=YYYY-MM-DD` is preparation-only, `task byosan:daily` is the full daily production path, and explicit publication follows the authorization boundary defined below.
 
 ## 4. Repository, product, and publication are separate verdicts
 
@@ -126,6 +112,30 @@ These YouTube profiles are distinct products:
 Publication is an irreversible external side effect. Use only the canonical Taskfile publication path, with an explicit profile and run. A code change, merge, rendered video, or local release preflight does not authorize or prove publication.
 
 Without remote receipt/read-back evidence, publication is not VERIFIED.
+
+### 秒算マネー local-agent publish-ready handoff
+
+When the requested outcome is “leave 秒算マネー ready to publish and hand it to a local agent”, the local agent must use this exact boundary:
+
+```bash
+git pull
+task setup
+task byosan:prepare DATE=YYYY-MM-DD
+```
+
+Rules:
+
+1. `DATE` must be explicitly supplied in `YYYY-MM-DD` form. Do not infer “today” or substitute another date.
+2. `task byosan:prepare` is the canonical preparation path. It performs research, production, audit, and the product release gate, but must not perform the external YouTube publication side effect.
+3. If preparation or the release gate fails, stop. Do not bypass, weaken, retry around, or replace the failed gate with manual publication.
+4. A run is **publish-ready** only when the command succeeds and emits all of the following evidence for the same run:
+   - `[product-release-gate] PASS ... artifact_sha256=<sha256>`
+   - `PUBLISH_READY_RUN=<run-id>`
+   - `PUBLISH_COMMAND=task publish PROFILE=byosan -- <run-id>`
+5. Record the exact run id, artifact SHA-256, and printed publish command in the governing Issue or requested handoff surface, then stop. The local agent must not execute `PUBLISH_COMMAND` unless the user separately and explicitly authorizes publication.
+6. After explicit publication authorization, use only the exact canonical `task publish PROFILE=byosan -- <run-id>` path. Publication becomes VERIFIED only after remote receipt/read-back/visibility evidence is obtained.
+
+The stop condition for a preparation-only handoff is therefore: exact artifact generated, product release gate PASS, exact publish command recorded, and no remote publication performed.
 
 ## 6. Change source, then validate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,32 @@ task stability:report
 
 Internal `src/scripts/*` and package scripts support Taskfile/CI; they are not a second human-facing interface unless explicitly documented as one.
 
+### Production execution is a target-host operation
+
+An explicit request to run/start/`動かす` production means executing the canonical production task on the target runtime. Repository validation, CI, tests, mocks, or `DRY_RUN` are not substitutes for that request.
+
+For 秒算マネー, use only these Taskfile entry points:
+
+```bash
+# Prepare and pass the local product release gate without publishing.
+task byosan:prepare DATE=YYYY-MM-DD
+
+# Full daily production path, including publication when its gates permit it.
+task byosan:daily
+
+# Explicit publication of an already prepared run.
+task publish PROFILE=byosan -- byosan_money/YYYY-MM-DD-daily
+```
+
+Rules:
+
+- run production commands on the target host that owns the required `config/.env.byosan`, OAuth credentials, media/runtime dependencies, and local services;
+- if authorized target-host execution capability is available, use it instead of stopping at repository or CI evidence;
+- never reinterpret a requested production run as “run CI” or “verify the code”;
+- never create an ad-hoc GitHub Actions workflow merely to bypass the target-host boundary;
+- if the current tool context cannot execute on the target host, report the runtime result as **UNVERIFIED** and state that the production command was not executed;
+- repository acceptance may be VERIFIED while product/runtime/publication remains separately UNVERIFIED.
+
 ## 4. Repository, product, and publication are separate verdicts
 
 | evidence | proves | does not prove |


### PR DESCRIPTION
## What changed
- define an explicit production execution contract in `AGENTS.md`
- distinguish requested production execution from CI/tests/DRY_RUN
- document `task byosan:prepare`, `task byosan:daily`, and explicit `task publish` roles
- require target-host execution when capability is available
- require `UNVERIFIED` reporting when the current tool context cannot execute on the target host
- prohibit ad-hoc GitHub Actions workflows as a substitute for the target runtime

## Scope
Documentation-only repository operating contract. No runtime behavior changes.