### PR TITLE
Remove unused XAI_API_KEY from weekly research

### DIFF
--- a/.github/workflows/weekly-repo-research.yml
+++ b/.github/workflows/weekly-repo-research.yml
@@ -15,5 +15,3 @@ jobs:
     permissions:
       contents: write
     uses: KAFKA2306/agent-resources/.github/workflows/reusable-weekly-repo-research.yml@main
-    secrets:
-      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}


### PR DESCRIPTION
Closes #69

Removes the unused XAI_API_KEY secret forwarding from the weekly research caller. The shared workflow currently uses local Ollama and primary sources, so this removes an unnecessary secret dependency without changing schedule or permissions.