### PR TITLE
Remove obsolete digest policy authority marker

### DIFF
--- a/src/scripts/build_byosan_digest.ts
+++ b/src/scripts/build_byosan_digest.ts
@@ -913,7 +913,7 @@ function writeDigestArtifacts(
 				status: "PASS",
 				critical: true,
 				details:
-					"Legacy reuse_only_no_new_material_claims authority is replaced by reuse_daily_assets_plus_verified_digest_bridge.",
+					"Canonical digest policy is reuse_daily_assets_plus_verified_digest_bridge.",
 			},
 		},
 		{ spaces: 2 },


### PR DESCRIPTION
## Summary

Post-merge read-back found the retired digest policy name still present in an audit description string. The executable authority had already moved to `reuse_daily_assets_plus_verified_digest_bridge`, but retaining the old literal could be misread as a second canonical policy.

This change removes the obsolete authority marker and leaves only the current canonical policy name.

Closes #89