### PR TITLE
Preserve Humanity pacing audit measurements

### DIFF
--- a/src/domain/agents/audit.ts
+++ b/src/domain/agents/audit.ts
@@ -98,13 +98,6 @@ export class AuditAgent extends BaseAgent {
 
 		// 1. SIGNAL AUDIT (DETERMINISTIC)
 		const signalResults = await this.auditSignals(state, evidence);
-		if (
-			state.bucket === "humanity_observatory" &&
-			signalResults.multimodal_pacing
-		) {
-			signalResults.multimodal_pacing.status = "PASS";
-			signalResults.multimodal_pacing.details += ` (Bypassed for ${state.bucket} production requirements)`;
-		}
 		Object.assign(results, signalResults);
 
 		// 2. POLICY AUDIT (DETERMINISTIC / REGEX)

--- a/tests/humanity_pacing_integrity.test.ts
+++ b/tests/humanity_pacing_integrity.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs-extra";
+
+describe("humanity pacing audit integrity", () => {
+	test("deterministic multimodal pacing is never overwritten after measurement", () => {
+		const source = fs.readFileSync("src/domain/agents/audit.ts", "utf8");
+		expect(source).not.toContain(
+			'signalResults.multimodal_pacing.status = "PASS"',
+		);
+		expect(source).not.toContain("Bypassed for ${state.bucket}");
+		expect(source).toContain("Object.assign(results, signalResults)");
+	});
+});


### PR DESCRIPTION
## Summary
- remove the Humanity-specific post-measurement mutation that converted multimodal pacing results to PASS
- keep deterministic signal evidence unchanged after auditSignals()
- add a regression guard against reintroducing the overwrite

## Verification
- exact-head CI before merge
- post-merge main read-back

Closes #95