### PR TITLE
Enforce no-fallback across Byosan media and prompt memory

### DIFF
--- a/data/memory/byosan_money/loop_journal.json
+++ b/data/memory/byosan_money/loop_journal.json
@@ -2,24 +2,6 @@
   "entries": [
     {
       "run_id": "daily_pulse/2026-05-29",
-      "bucket": "default",
-      "stage": "content",
-      "kind": "fallback",
-      "summary": "LLM quota exhaustion forced deterministic fallback content. The loop should skip wasted retries and bias future runs toward cached research plus fallback-safe synthesis.",
-      "signals": [
-        "rate limit / quota exhaustion",
-        "3 attempted generations failed",
-        "deterministic fallback preserved pipeline continuity"
-      ],
-      "fixes": [
-        "treat quota exhaustion as a terminal content-state, not a recoverable generation error",
-        "prime future runs with cached research and loop memory",
-        "prefer concise, audit-safe fallback patterns when the model pool is dry"
-      ],
-      "timestamp": "2026-05-29T14:58:13.425Z"
-    },
-    {
-      "run_id": "daily_pulse/2026-05-29",
       "bucket": "daily_pulse",
       "stage": "audit",
       "kind": "failure",
@@ -56,24 +38,6 @@
         "prime the next loop with the specific failing check names"
       ],
       "timestamp": "2026-05-30T09:00:15.856Z"
-    },
-    {
-      "run_id": "daily_pulse/2026-05-30",
-      "bucket": "default",
-      "stage": "content",
-      "kind": "fallback",
-      "summary": "LLM quota exhaustion forced deterministic fallback content. The loop should skip wasted retries and bias future runs toward cached research plus fallback-safe synthesis.",
-      "signals": [
-        "rate limit / quota exhaustion",
-        "3 attempted generations failed",
-        "deterministic fallback preserved pipeline continuity"
-      ],
-      "fixes": [
-        "treat quota exhaustion as a terminal content-state, not a recoverable generation error",
-        "prime future runs with cached research and loop memory",
-        "prefer concise, audit-safe fallback patterns when the model pool is dry"
-      ],
-      "timestamp": "2026-05-30T09:08:58.312Z"
     },
     {
       "run_id": "daily_pulse/2026-05-30",
@@ -141,24 +105,6 @@
     },
     {
       "run_id": "daily_pulse/2026-06-05",
-      "bucket": "default",
-      "stage": "content",
-      "kind": "fallback",
-      "summary": "LLM quota exhaustion forced deterministic fallback content. The loop should skip wasted retries and bias future runs toward cached research plus fallback-safe synthesis.",
-      "signals": [
-        "rate limit / quota exhaustion",
-        "3 attempted generations failed",
-        "deterministic fallback preserved pipeline continuity"
-      ],
-      "fixes": [
-        "treat quota exhaustion as a terminal content-state, not a recoverable generation error",
-        "prime future runs with cached research and loop memory",
-        "prefer concise, audit-safe fallback patterns when the model pool is dry"
-      ],
-      "timestamp": "2026-06-05T06:49:36.566Z"
-    },
-    {
-      "run_id": "daily_pulse/2026-06-05",
       "bucket": "daily_pulse",
       "stage": "audit",
       "kind": "failure",
@@ -206,24 +152,6 @@
         "prime the next loop with the specific failing check names"
       ],
       "timestamp": "2026-06-06T00:18:01.047Z"
-    },
-    {
-      "run_id": "daily_pulse/2026-06-06",
-      "bucket": "default",
-      "stage": "content",
-      "kind": "fallback",
-      "summary": "LLM quota exhaustion forced deterministic fallback content. The loop should skip wasted retries and bias future runs toward cached research plus fallback-safe synthesis.",
-      "signals": [
-        "rate limit / quota exhaustion",
-        "3 attempted generations failed",
-        "deterministic fallback preserved pipeline continuity"
-      ],
-      "fixes": [
-        "treat quota exhaustion as a terminal content-state, not a recoverable generation error",
-        "prime future runs with cached research and loop memory",
-        "prefer concise, audit-safe fallback patterns when the model pool is dry"
-      ],
-      "timestamp": "2026-06-06T04:07:56.929Z"
     },
     {
       "run_id": "daily_pulse/2026-06-06",

--- a/src/scripts/audit_no_fallback_policy.ts
+++ b/src/scripts/audit_no_fallback_policy.ts
@@ -16,6 +16,7 @@ const SOURCE_ROOTS = [
 	"config",
 	"Taskfile.yml",
 	"package.json",
+	"data/memory",
 ];
 const FORBIDDEN_CODE_PATTERNS = [
 	/FALLBACK_SUCCESS/,
@@ -27,6 +28,9 @@ const FORBIDDEN_CODE_PATTERNS = [
 	/ls\s+-td[^\n]*runs\/[^\n]*\|\s*head\s+-n\s*1/,
 	/kind:\s*["']fallback["']/,
 	/usedFallback/,
+	/CHARACTER_FALLBACK/,
+	/fallbackCharacterSvg/,
+	/fallback-safe\s+synthesis/i,
 ];
 const ALLOWED_PATTERN_FILES = new Set([
 	"src/scripts/audit_no_fallback_policy.ts",

--- a/src/scripts/produce_byosan_feature.ts
+++ b/src/scripts/produce_byosan_feature.ts
@@ -502,22 +502,6 @@ function sceneSvg(
 	</svg>`);
 }
 
-function fallbackCharacterSvg(speaker: FeatureSegment["speaker"]): Buffer {
-	const isZundamon = speaker === "ずんだもん";
-	const accent = isZundamon ? "#84CC55" : VISUAL_IDENTITY.primaryAccent;
-	const accent2 = isZundamon ? "#D7F76D" : VISUAL_IDENTITY.secondaryAccent;
-	return Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="720" height="900" viewBox="0 0 720 900">
-		<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop stop-color="${accent}"/><stop offset="1" stop-color="${accent2}"/></linearGradient></defs>
-		<circle cx="360" cy="300" r="220" fill="${accent}" fill-opacity="0.10" stroke="${accent}" stroke-opacity="0.28" stroke-width="4"/>
-		<circle cx="360" cy="292" r="126" fill="url(#g)"/>
-		<circle cx="322" cy="278" r="12" fill="${VISUAL_IDENTITY.background}"/><circle cx="398" cy="278" r="12" fill="${VISUAL_IDENTITY.background}"/>
-		<path d="M326 333 Q360 360 394 333" fill="none" stroke="${VISUAL_IDENTITY.background}" stroke-width="10" stroke-linecap="round"/>
-		<path d="M138 840 Q174 515 360 492 Q546 515 582 840 Z" fill="url(#g)" opacity="0.92"/>
-		<rect x="110" y="730" width="500" height="96" rx="48" fill="${VISUAL_IDENTITY.background}" fill-opacity="0.92" stroke="${accent}" stroke-width="3"/>
-		<text x="360" y="792" text-anchor="middle" font-family="Noto Sans CJK JP, sans-serif" font-size="42" font-weight="800" fill="${VISUAL_IDENTITY.textPrimary}">${speaker}</text>
-	</svg>`);
-}
-
 async function characterSourceBuffer(
 	speaker: FeatureSegment["speaker"],
 ): Promise<Buffer> {
@@ -528,9 +512,10 @@ async function characterSourceBuffer(
 					PROJECT_ROOT,
 					"assets/春日部つむぎ立ち絵公式_v2.0/春日部つむぎ立ち絵公式_v2.0.png",
 				);
-	if (await fs.pathExists(source)) return fs.readFile(source);
-	console.warn(`[CHARACTER_FALLBACK] ${speaker}: ${source}`);
-	return fallbackCharacterSvg(speaker);
+	if (!(await fs.pathExists(source))) {
+		throw new Error(`BYOSAN_CHARACTER_ASSET_MISSING: ${speaker}: ${source}`);
+	}
+	return fs.readFile(source);
 }
 
 async function characterBuffer(

--- a/tests/byosan_no_fallback_effective_inputs.test.ts
+++ b/tests/byosan_no_fallback_effective_inputs.test.ts
@@ -3,24 +3,24 @@ import fs from "fs-extra";
 
 describe("effective no-fallback inputs", () => {
 	test("Byosan media fails closed when canonical character assets are missing", () => {
-			const source = fs.readFileSync(
-				"src/scripts/produce_byosan_feature.ts",
-				"utf8",
-			);
-			expect(source).toContain("BYOSAN_CHARACTER_ASSET_MISSING");
-			expect(source).not.toContain("fallbackCharacterSvg");
-			expect(source).not.toContain("CHARACTER_FALLBACK");
+		const source = fs.readFileSync(
+			"src/scripts/produce_byosan_feature.ts",
+			"utf8",
+		);
+		expect(source).toContain("BYOSAN_CHARACTER_ASSET_MISSING");
+		expect(source).not.toContain("fallbackCharacterSvg");
+		expect(source).not.toContain("CHARACTER_FALLBACK");
 	});
 
 	test("no-fallback audit covers prompt memory and media fallback markers", () => {
-			const source = fs.readFileSync(
-				"src/scripts/audit_no_fallback_policy.ts",
-				"utf8",
-			);
-			expect(source).toContain('"data/memory"');
-			expect(source).toContain("/CHARACTER_FALLBACK/");
-			expect(source).toContain("/fallbackCharacterSvg/");
-			expect(source).toContain("/fallback-safe\\s+synthesis/i");
+		const source = fs.readFileSync(
+			"src/scripts/audit_no_fallback_policy.ts",
+			"utf8",
+		);
+		expect(source).toContain('"data/memory"');
+		expect(source).toContain("/CHARACTER_FALLBACK/");
+		expect(source).toContain("/fallbackCharacterSvg/");
+		expect(source).toContain("/fallback-safe\\s+synthesis/i");
 	});
 
 	test("active Byosan loop memory contains no fallback entries", () => {
@@ -30,11 +30,11 @@ describe("effective no-fallback inputs", () => {
 			entries?: Array<{ kind?: string; summary?: string; fixes?: string[] }>;
 		};
 		for (const entry of memory.entries ?? []) {
-			expect(entry.kind).not.toBe("fallback");
-			expect(entry.summary ?? "").not.toMatch(/fallback-safe\s+synthesis/i);
-			expect((entry.fixes ?? []).join(" ")).not.toMatch(
+		expect(entry.kind).not.toBe("fallback");
+		expect(entry.summary ?? "").not.toMatch(/fallback-safe\s+synthesis/i);
+		expect((entry.fixes ?? []).join(" ")).not.toMatch(
 				/fallback-safe\s+synthesis/i,
-			);
+		);
 		}
 	});
 });

--- a/tests/byosan_no_fallback_effective_inputs.test.ts
+++ b/tests/byosan_no_fallback_effective_inputs.test.ts
@@ -30,11 +30,11 @@ describe("effective no-fallback inputs", () => {
 			entries?: Array<{ kind?: string; summary?: string; fixes?: string[] }>;
 		};
 		for (const entry of memory.entries ?? []) {
-		expect(entry.kind).not.toBe("fallback");
-		expect(entry.summary ?? "").not.toMatch(/fallback-safe\s+synthesis/i);
-		expect((entry.fixes ?? []).join(" ")).not.toMatch(
+			expect(entry.kind).not.toBe("fallback");
+			expect(entry.summary ?? "").not.toMatch(/fallback-safe\s+synthesis/i);
+			expect((entry.fixes ?? []).join(" ")).not.toMatch(
 				/fallback-safe\s+synthesis/i,
-		);
+			);
 		}
 	});
 });

--- a/tests/byosan_no_fallback_effective_inputs.test.ts
+++ b/tests/byosan_no_fallback_effective_inputs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs-extra";
+
+describe("effective no-fallback inputs", () => {
+	test("Byosan media fails closed when canonical character assets are missing", () => {
+			const source = fs.readFileSync(
+				"src/scripts/produce_byosan_feature.ts",
+				"utf8",
+			);
+			expect(source).toContain("BYOSAN_CHARACTER_ASSET_MISSING");
+			expect(source).not.toContain("fallbackCharacterSvg");
+			expect(source).not.toContain("CHARACTER_FALLBACK");
+	});
+
+	test("no-fallback audit covers prompt memory and media fallback markers", () => {
+			const source = fs.readFileSync(
+				"src/scripts/audit_no_fallback_policy.ts",
+				"utf8",
+			);
+			expect(source).toContain('"data/memory"');
+			expect(source).toContain("/CHARACTER_FALLBACK/");
+			expect(source).toContain("/fallbackCharacterSvg/");
+			expect(source).toContain("/fallback-safe\\s+synthesis/i");
+	});
+
+	test("active Byosan loop memory contains no fallback entries", () => {
+		const memory = fs.readJsonSync(
+			"data/memory/byosan_money/loop_journal.json",
+		) as {
+			entries?: Array<{ kind?: string; summary?: string; fixes?: string[] }>;
+		};
+		for (const entry of memory.entries ?? []) {
+			expect(entry.kind).not.toBe("fallback");
+			expect(entry.summary ?? "").not.toMatch(/fallback-safe\s+synthesis/i);
+			expect((entry.fixes ?? []).join(" ")).not.toMatch(
+				/fallback-safe\s+synthesis/i,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- fail closed when canonical Byosan character assets are missing
- remove generated SVG character fallback
- extend no-fallback source audit to active memory inputs
- remove retired fallback-recommendation entries from Byosan loop memory
- add regression guards for media fallback markers and prompt-memory fallback policy

## Verification
- exact-head CI before merge
- post-merge main read-back

Closes #96