### PR TITLE
Fail Byosan full runtime gate on UNVERIFIED dependencies

### DIFF
--- a/src/scripts/verify_byosan_runtime.ts
+++ b/src/scripts/verify_byosan_runtime.ts
@@ -302,8 +302,7 @@ async function main(): Promise<void> {
 	appendStep(reportPath, params, "preflight", preflight);
 	if (preflight.status !== "PASS") {
 		writeReport(reportPath, params);
-		console.log(`BYOSAN_RUNTIME_UNVERIFIED=${reportPath}`);
-		return;
+		throw new Error(`BYOSAN_RUNTIME_UNVERIFIED: ${reportPath}`);
 	}
 
 	const env = {

--- a/tests/byosan_runtime_gate.test.ts
+++ b/tests/byosan_runtime_gate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs-extra";
+
+describe("Byosan full runtime gate", () => {
+	test("UNVERIFIED preflight is a failing gate, not a successful workflow exit", () => {
+		const source = fs.readFileSync(
+			"src/scripts/verify_byosan_runtime.ts",
+			"utf8",
+		);
+		expect(source).toContain("BYOSAN_RUNTIME_UNVERIFIED:");
+		expect(source).not.toContain(
+			'console.log(`BYOSAN_RUNTIME_UNVERIFIED=${reportPath}`);\n\t\treturn;',
+		);
+		expect(source).toContain("writeReport(reportPath, params)");
+	});
+});

--- a/tests/byosan_runtime_gate.test.ts
+++ b/tests/byosan_runtime_gate.test.ts
@@ -9,7 +9,7 @@ describe("Byosan full runtime gate", () => {
 		);
 		expect(source).toContain("BYOSAN_RUNTIME_UNVERIFIED:");
 		expect(source).not.toContain(
-			'console.log(`BYOSAN_RUNTIME_UNVERIFIED=${reportPath}`);\n\t\treturn;',
+			"console.log(`BYOSAN_RUNTIME_UNVERIFIED=${reportPath}`);\n\t\treturn;",
 		);
 		expect(source).toContain("writeReport(reportPath, params)");
 	});


### PR DESCRIPTION
## Summary
- retain the full runtime evidence JSON when preflight is UNVERIFIED
- exit non-zero instead of allowing the self-hosted workflow to appear successful
- keep hosted Active Probe smoke behavior unchanged

## Verification
- regression guard for UNVERIFIED gate behavior
- exact-head CI before merge
- post-merge main read-back

Closes #93