### PR TITLE
Pin write-capable weekly research workflow to immutable revision

### DIFF
--- a/.github/workflows/weekly-repo-research.yml
+++ b/.github/workflows/weekly-repo-research.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   research:
+    # Required because the pinned reusable workflow commits research/weekly back to this repository.
     permissions:
       contents: write
-    uses: KAFKA2306/agent-resources/.github/workflows/reusable-weekly-repo-research.yml@main
+    uses: KAFKA2306/agent-resources/.github/workflows/reusable-weekly-repo-research.yml@e1f12ec1532719f2ea970be65eababed6475e168

--- a/tests/workflow_supply_chain.test.ts
+++ b/tests/workflow_supply_chain.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs-extra";
+
+describe("reusable workflow supply-chain pinning", () => {
+	test("write-capable external reusable workflows use immutable revisions", () => {
+		const workflow = fs.readFileSync(
+			".github/workflows/weekly-repo-research.yml",
+			"utf8",
+		);
+		expect(workflow).toContain("contents: write");
+		expect(workflow).not.toMatch(
+			/uses:\s+KAFKA2306\/agent-resources\/\.github\/workflows\/[^\s]+@(main|master|v\d+)\b/,
+		);
+		expect(workflow).toMatch(
+			/uses:\s+KAFKA2306\/agent-resources\/\.github\/workflows\/[^\s]+@[0-9a-f]{40}\b/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- pin the external weekly research reusable workflow to the exact current agent-resources main commit
- retain contents: write only because that reusable workflow commits research/weekly back to the caller repository
- add a static regression guard against mutable external revisions on this write-capable path

Pinned revision: `e1f12ec1532719f2ea970be65eababed6475e168`

## Verification
- verified the pinned SHA is identical to current agent-resources main at implementation time
- exact-head CI before merge
- post-merge main read-back

Closes #97