### PR TITLE
feat(byosan): add anti-gaming analytics evaluation contract

### DIFF
--- a/src/domain/byosan/performance_evaluation.ts
+++ b/src/domain/byosan/performance_evaluation.ts
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { ByosanProductionFormatSchema } from "./news_angle.js";
+
+export const ByosanAnalyticsMetricSchema = z.enum([
+	"views",
+	"watchTimeMinutes",
+	"averageViewPercentage",
+	"subscribersGained",
+]);
+
+export const ByosanAnalyticsMetricVectorSchema = z.object({
+	views: z.number().min(0),
+	watchTimeMinutes: z.number().min(0),
+	averageViewPercentage: z.number().min(0).max(100),
+	subscribersGained: z.number(),
+});
+
+export const ByosanAnalyticsEvaluationPlanSchema = z
+	.object({
+		schemaVersion: z.literal("byosan_analytics_evaluation_plan_v1"),
+		baselineRevision: z.string().min(7).max(80),
+		policyVersion: z.string().min(1).max(80),
+		format: ByosanProductionFormatSchema,
+		packagingKnobs: z
+			.array(
+				z.enum([
+					"freshness",
+					"relative_anchor",
+					"impact",
+					"duration_bucket",
+					"title_structure",
+				]),
+			)
+			.min(1),
+		window: z.literal("first_7d"),
+		sampleMinimum: z.number().int().min(2),
+		primaryMetric: ByosanAnalyticsMetricSchema,
+		secondaryMetrics: z.array(ByosanAnalyticsMetricSchema).min(3).max(3),
+		metricFloors: ByosanAnalyticsMetricVectorSchema,
+		hardGateNames: z.array(z.string().min(1)).min(1),
+		createdAt: z.string().datetime(),
+	})
+	.superRefine((plan, context) => {
+		const metrics = new Set([plan.primaryMetric, ...plan.secondaryMetrics]);
+		for (const metric of ByosanAnalyticsMetricSchema.options) {
+			if (!metrics.has(metric)) {
+				context.addIssue({
+					code: "custom",
+					path: ["secondaryMetrics"],
+					message: `evaluation plan must include metric ${metric}`,
+				});
+			}
+		}
+		if (metrics.size !== 4) {
+			context.addIssue({
+				code: "custom",
+				path: ["secondaryMetrics"],
+				message: "evaluation metrics must be unique",
+			});
+		}
+	});
+
+export const ByosanAnalyticsEvaluationCandidateSchema = z.object({
+	candidateId: z.string().min(1),
+	evaluationUnitId: z.string().min(1),
+	attemptNumber: z.number().int().min(1),
+	format: ByosanProductionFormatSchema,
+	packagingPattern: z.string().min(1),
+	evidenceKind: z.enum(["production", "synthetic"]),
+	hardGateFailures: z.array(z.string().min(1)),
+	metrics: ByosanAnalyticsMetricVectorSchema,
+});
+
+export const ByosanAnalyticsEvaluationUnitSchema = z.object({
+	evaluationUnitId: z.string().min(1),
+	selectedCandidateId: z.string().min(1),
+	firstAttemptNumber: z.number().int().min(1),
+	attemptCount: z.number().int().min(1),
+	verdict: z.enum(["PASS", "REJECTED", "UNVERIFIED"]),
+	reasonCodes: z.array(z.string()),
+	metrics: ByosanAnalyticsMetricVectorSchema,
+});
+
+export const ByosanAnalyticsEvaluationResultSchema = z.object({
+	schemaVersion: z.literal("byosan_analytics_evaluation_result_v1"),
+	planHash: z.string().regex(/^[a-f0-9]{64}$/),
+	status: z.enum(["READY", "INSUFFICIENT_DATA"]),
+	sampleCount: z.number().int().min(0),
+	eligibleCount: z.number().int().min(0),
+	preferredEvaluationUnitId: z.string().min(1).optional(),
+	units: z.array(ByosanAnalyticsEvaluationUnitSchema),
+});
+
+export type ByosanAnalyticsEvaluationPlan = z.infer<
+	typeof ByosanAnalyticsEvaluationPlanSchema
+>;
+export type ByosanAnalyticsEvaluationCandidate = z.infer<
+	typeof ByosanAnalyticsEvaluationCandidateSchema
+>;
+export type ByosanAnalyticsEvaluationResult = z.infer<
+	typeof ByosanAnalyticsEvaluationResultSchema
+>;
+
+function canonicalize(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, child]) => [key, canonicalize(child)]),
+		);
+	}
+	return value;
+}
+
+export function hashByosanAnalyticsEvaluationPlan(
+	planInput: ByosanAnalyticsEvaluationPlan,
+): string {
+	const plan = ByosanAnalyticsEvaluationPlanSchema.parse(planInput);
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalize(plan)))
+		.digest("hex");
+}
+
+function metricFloorFailures(
+	plan: ByosanAnalyticsEvaluationPlan,
+	metrics: z.infer<typeof ByosanAnalyticsMetricVectorSchema>,
+): string[] {
+	return ByosanAnalyticsMetricSchema.options.flatMap((metric) =>
+		metrics[metric] < plan.metricFloors[metric]
+			? [`metric_floor_failed:${metric}`]
+			: [],
+	);
+}
+
+function compareMetrics(
+	plan: ByosanAnalyticsEvaluationPlan,
+	left: z.infer<typeof ByosanAnalyticsEvaluationUnitSchema>,
+	right: z.infer<typeof ByosanAnalyticsEvaluationUnitSchema>,
+): number {
+	const orderedMetrics = [plan.primaryMetric, ...plan.secondaryMetrics];
+	for (const metric of orderedMetrics) {
+		const delta = right.metrics[metric] - left.metrics[metric];
+		if (delta !== 0) return delta;
+	}
+	return left.evaluationUnitId.localeCompare(right.evaluationUnitId);
+}
+
+export function evaluateByosanAnalyticsCandidates(
+	planInput: ByosanAnalyticsEvaluationPlan,
+	candidateInputs: ByosanAnalyticsEvaluationCandidate[],
+): ByosanAnalyticsEvaluationResult {
+	const plan = ByosanAnalyticsEvaluationPlanSchema.parse(planInput);
+	const candidates = candidateInputs.map((candidate) =>
+		ByosanAnalyticsEvaluationCandidateSchema.parse(candidate),
+	);
+	const grouped = new Map<string, ByosanAnalyticsEvaluationCandidate[]>();
+	for (const candidate of candidates) {
+		const group = grouped.get(candidate.evaluationUnitId) ?? [];
+		group.push(candidate);
+		grouped.set(candidate.evaluationUnitId, group);
+	}
+
+	const units = [...grouped.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([evaluationUnitId, attempts]) => {
+			const ordered = [...attempts].sort(
+				(left, right) =>
+					left.attemptNumber - right.attemptNumber ||
+					left.candidateId.localeCompare(right.candidateId),
+			);
+			const first = ordered[0];
+			if (!first) {
+				throw new Error("BYOSAN_ANALYTICS_EVALUATION_UNIT_EMPTY");
+			}
+			const reasonCodes: string[] = [];
+			let verdict: "PASS" | "REJECTED" | "UNVERIFIED" = "PASS";
+			if (first.evidenceKind === "synthetic") {
+				verdict = "UNVERIFIED";
+				reasonCodes.push("synthetic_evidence_not_production");
+			}
+			if (first.format !== plan.format) {
+				verdict = "REJECTED";
+				reasonCodes.push("format_out_of_evaluation_plan");
+			}
+			if (first.hardGateFailures.length > 0) {
+				verdict = "REJECTED";
+				reasonCodes.push(
+					...first.hardGateFailures.map((failure) => `hard_gate_failed:${failure}`),
+				);
+			}
+			const floorFailures = metricFloorFailures(plan, first.metrics);
+			if (floorFailures.length > 0) {
+				verdict = "REJECTED";
+				reasonCodes.push(...floorFailures);
+			}
+			if (ordered.length > 1) {
+				reasonCodes.push(`retry_attempts_ignored:${ordered.length - 1}`);
+			}
+			return ByosanAnalyticsEvaluationUnitSchema.parse({
+				evaluationUnitId,
+				selectedCandidateId: first.candidateId,
+				firstAttemptNumber: first.attemptNumber,
+				attemptCount: ordered.length,
+				verdict,
+				reasonCodes,
+				metrics: first.metrics,
+			});
+		});
+
+	const productionSampleCount = units.filter(
+		(unit) =>
+			unit.verdict !== "UNVERIFIED" &&
+			!unit.reasonCodes.includes("format_out_of_evaluation_plan"),
+	).length;
+	const eligible = units
+		.filter((unit) => unit.verdict === "PASS")
+		.sort((left, right) => compareMetrics(plan, left, right));
+	const status =
+		productionSampleCount >= plan.sampleMinimum && eligible.length > 0
+			? "READY"
+			: "INSUFFICIENT_DATA";
+	return ByosanAnalyticsEvaluationResultSchema.parse({
+		schemaVersion: "byosan_analytics_evaluation_result_v1",
+		planHash: hashByosanAnalyticsEvaluationPlan(plan),
+		status,
+		sampleCount: productionSampleCount,
+		eligibleCount: eligible.length,
+		...(status === "READY" && eligible[0]
+			? { preferredEvaluationUnitId: eligible[0].evaluationUnitId }
+			: {}),
+		units,
+	});
+}

--- a/src/domain/byosan/performance_evaluation.ts
+++ b/src/domain/byosan/performance_evaluation.ts
@@ -187,7 +187,9 @@ export function evaluateByosanAnalyticsCandidates(
 			if (first.hardGateFailures.length > 0) {
 				verdict = "REJECTED";
 				reasonCodes.push(
-					...first.hardGateFailures.map((failure) => `hard_gate_failed:${failure}`),
+					...first.hardGateFailures.map(
+						(failure) => `hard_gate_failed:${failure}`,
+					),
 				);
 			}
 			const floorFailures = metricFloorFailures(plan, first.metrics);

--- a/tests/byosan_performance_evaluation.test.ts
+++ b/tests/byosan_performance_evaluation.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import {
+	evaluateByosanAnalyticsCandidates,
+	hashByosanAnalyticsEvaluationPlan,
+	type ByosanAnalyticsEvaluationCandidate,
+	type ByosanAnalyticsEvaluationPlan,
+} from "../src/domain/byosan/performance_evaluation.js";
+
+function plan(): ByosanAnalyticsEvaluationPlan {
+	return {
+		schemaVersion: "byosan_analytics_evaluation_plan_v1",
+		baselineRevision: "58ec83c2c03926ed150c430b9be85bdb739f0607",
+		policyVersion: "anti_gaming_v1",
+		format: "comparison",
+		packagingKnobs: ["relative_anchor", "title_structure"],
+		window: "first_7d",
+		sampleMinimum: 2,
+		primaryMetric: "averageViewPercentage",
+		secondaryMetrics: ["watchTimeMinutes", "subscribersGained", "views"],
+		metricFloors: {
+			views: 500,
+			watchTimeMinutes: 200,
+			averageViewPercentage: 45,
+			subscribersGained: 0,
+		},
+		hardGateNames: [
+			"factual_integrity",
+			"source_quality",
+			"narrative_contract",
+		],
+		createdAt: "2026-09-07T03:00:00.000Z",
+	};
+}
+
+function candidate(
+	overrides: Partial<ByosanAnalyticsEvaluationCandidate> = {},
+): ByosanAnalyticsEvaluationCandidate {
+	return {
+		candidateId: "candidate-a1",
+		evaluationUnitId: "run-a",
+		attemptNumber: 1,
+		format: "comparison",
+		packagingPattern: "relative",
+		evidenceKind: "production",
+		hardGateFailures: [],
+		metrics: {
+			views: 1000,
+			watchTimeMinutes: 500,
+			averageViewPercentage: 60,
+			subscribersGained: 10,
+		},
+		...overrides,
+	};
+}
+
+describe("byosan analytics anti-gaming evaluation", () => {
+	test("retry attempts are not independent samples or best-of-N candidates", () => {
+		const result = evaluateByosanAnalyticsCandidates(plan(), [
+			candidate({
+				candidateId: "run-a-first",
+				evaluationUnitId: "run-a",
+				attemptNumber: 1,
+				metrics: {
+					views: 900,
+					watchTimeMinutes: 410,
+					averageViewPercentage: 55,
+					subscribersGained: 8,
+				},
+			}),
+			candidate({
+				candidateId: "run-a-lucky-retry",
+				evaluationUnitId: "run-a",
+				attemptNumber: 2,
+				metrics: {
+					views: 99999,
+					watchTimeMinutes: 99999,
+					averageViewPercentage: 99,
+					subscribersGained: 999,
+				},
+			}),
+			candidate({
+				candidateId: "run-b-first",
+				evaluationUnitId: "run-b",
+				metrics: {
+					views: 1200,
+					watchTimeMinutes: 600,
+					averageViewPercentage: 65,
+					subscribersGained: 12,
+				},
+			}),
+		]);
+		expect(result.status).toBe("READY");
+		expect(result.sampleCount).toBe(2);
+		expect(result.preferredEvaluationUnitId).toBe("run-b");
+		const runA = result.units.find((unit) => unit.evaluationUnitId === "run-a");
+		expect(runA?.selectedCandidateId).toBe("run-a-first");
+		expect(runA?.reasonCodes).toContain("retry_attempts_ignored:1");
+	});
+
+	test("hard gate failure cannot be offset by engagement", () => {
+		const result = evaluateByosanAnalyticsCandidates(plan(), [
+			candidate({
+				evaluationUnitId: "bad-facts",
+				candidateId: "bad-facts-a1",
+				hardGateFailures: ["factual_integrity"],
+				metrics: {
+					views: 1000000,
+					watchTimeMinutes: 100000,
+					averageViewPercentage: 99,
+					subscribersGained: 10000,
+				},
+			}),
+			candidate({
+				evaluationUnitId: "good-a",
+				candidateId: "good-a1",
+			}),
+		]);
+		const rejected = result.units.find(
+			(unit) => unit.evaluationUnitId === "bad-facts",
+		);
+		expect(rejected?.verdict).toBe("REJECTED");
+		expect(rejected?.reasonCodes).toContain(
+			"hard_gate_failed:factual_integrity",
+		);
+		expect(result.preferredEvaluationUnitId).toBe("good-a");
+	});
+
+	test("one metric below its floor rejects the candidate instead of averaging it away", () => {
+		const result = evaluateByosanAnalyticsCandidates(plan(), [
+			candidate({
+				evaluationUnitId: "low-retention",
+				candidateId: "low-retention-a1",
+				metrics: {
+					views: 50000,
+					watchTimeMinutes: 10000,
+					averageViewPercentage: 44,
+					subscribersGained: 200,
+				},
+			}),
+			candidate({
+				evaluationUnitId: "good-a",
+				candidateId: "good-a1",
+			}),
+		]);
+		const rejected = result.units.find(
+			(unit) => unit.evaluationUnitId === "low-retention",
+		);
+		expect(rejected?.verdict).toBe("REJECTED");
+		expect(rejected?.reasonCodes).toContain(
+			"metric_floor_failed:averageViewPercentage",
+		);
+	});
+
+	test("synthetic evidence never counts as production effect", () => {
+		const result = evaluateByosanAnalyticsCandidates(plan(), [
+			candidate({
+				evaluationUnitId: "fixture",
+				candidateId: "fixture-a1",
+				evidenceKind: "synthetic",
+			}),
+			candidate({
+				evaluationUnitId: "real",
+				candidateId: "real-a1",
+			}),
+		]);
+		expect(result.sampleCount).toBe(1);
+		expect(result.status).toBe("INSUFFICIENT_DATA");
+		expect(
+			result.units.find((unit) => unit.evaluationUnitId === "fixture")?.verdict,
+		).toBe("UNVERIFIED");
+	});
+
+	test("evaluation plan hash changes when the frozen policy changes", () => {
+		const original = plan();
+		const changed = { ...original, sampleMinimum: original.sampleMinimum + 1 };
+		expect(hashByosanAnalyticsEvaluationPlan(original)).not.toBe(
+			hashByosanAnalyticsEvaluationPlan(changed),
+		);
+	});
+});

--- a/tests/byosan_performance_evaluation.test.ts
+++ b/tests/byosan_performance_evaluation.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-	evaluateByosanAnalyticsCandidates,
-	hashByosanAnalyticsEvaluationPlan,
 	type ByosanAnalyticsEvaluationCandidate,
 	type ByosanAnalyticsEvaluationPlan,
+	evaluateByosanAnalyticsCandidates,
+	hashByosanAnalyticsEvaluationPlan,
 } from "../src/domain/byosan/performance_evaluation.js";
 
 function plan(): ByosanAnalyticsEvaluationPlan {


### PR DESCRIPTION
Closes #109

- freeze analytics evaluation policy with a stable plan hash
- require all four engagement metrics and per-metric floors
- make factual/source/narrative hard-gate failures non-compensable
- collapse retries into one evaluation unit and use the first attempt
- exclude synthetic evidence from production sample counts
- add deterministic best-of-N, hard-gate, floor, and plan-hash tests