### PR TITLE
feat(byosan): audit prompt debt before model migrations

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,6 +199,10 @@ tasks:
     desc: "Verify Taskfile executables and documented repository entry points"
     cmds: ["bun src/scripts/audit_repository_contract.ts"]
 
+  audit:prompt-migration:
+    desc: "Inventory prompt sources and audit model/profile migration debt"
+    cmds: ["bun src/scripts/audit_prompt_migration.ts {{.CLI_ARGS}}"]
+
   stability:report:
     desc: "Regenerate the canonical cross-run stability report"
     cmds: ["bun src/scripts/stability_summary.ts"]

--- a/src/domain/byosan/prompt_migration.ts
+++ b/src/domain/byosan/prompt_migration.ts
@@ -186,7 +186,7 @@ export function discoverByosanPromptInventory(
 
 	for (const relativePath of collectFiles(root, "src").sort()) {
 		const text = fs.readFileSync(path.join(root, relativePath), "utf-8");
-		if (/role\s*:\s*["']system["']|systemInstruction/i.test(text)) {
+		if (/role\s*:\s*["']system["']\s*,|systemInstruction\s*:/i.test(text)) {
 			records.push(
 				recordForSource(relativePath, "system", text, contractVersion),
 			);

--- a/src/domain/byosan/prompt_migration.ts
+++ b/src/domain/byosan/prompt_migration.ts
@@ -1,0 +1,385 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+const PromptAuthoritySchema = z.enum(["repository", "system", "developer"]);
+const PromptProgressPolicySchema = z.enum([
+	"required",
+	"forbidden",
+	"unspecified",
+]);
+const PromptConfirmationPolicySchema = z.enum([
+	"required",
+	"bypass_reversible",
+	"unspecified",
+]);
+
+export const ByosanPromptPolicySignalsSchema = z.object({
+	progressUpdates: PromptProgressPolicySchema,
+	confirmation: PromptConfirmationPolicySchema,
+});
+
+export const ByosanPromptSourceRecordSchema = z.object({
+	sourcePath: z.string().min(1),
+	authority: PromptAuthoritySchema,
+	promptHash: z.string().regex(/^[a-f0-9]{64}$/),
+	providerProfileApplicability: z.array(z.string().min(1)).min(1),
+	contractVersion: z.string().min(1),
+	signals: ByosanPromptPolicySignalsSchema,
+});
+
+export const ByosanPromptInventorySchema = z.object({
+	schemaVersion: z.literal("byosan_prompt_inventory_v1"),
+	modelProfile: z.string().min(1),
+	contractVersion: z.string().min(1),
+	generatedAt: z.string().datetime(),
+	records: z.array(ByosanPromptSourceRecordSchema),
+});
+
+export const ByosanPromptMigrationIssueSchema = z.object({
+	severity: z.enum(["FAIL", "WARN"]),
+	code: z.string().min(1),
+	details: z.string().min(1),
+});
+
+export const ByosanPromptInventoryDiffSchema = z.object({
+	modelProfileChanged: z.boolean(),
+	added: z.array(z.string()),
+	removed: z.array(z.string()),
+	changed: z.array(z.string()),
+});
+
+export type ByosanPromptSourceRecord = z.infer<
+	typeof ByosanPromptSourceRecordSchema
+>;
+export type ByosanPromptInventory = z.infer<typeof ByosanPromptInventorySchema>;
+export type ByosanPromptMigrationIssue = z.infer<
+	typeof ByosanPromptMigrationIssueSchema
+>;
+export type ByosanPromptInventoryDiff = z.infer<
+	typeof ByosanPromptInventoryDiffSchema
+>;
+
+function sha256(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
+}
+
+function normalize(text: string): string {
+	return text.normalize("NFKC").toLowerCase();
+}
+
+function detectProviderTags(text: string): string[] {
+	const normalized = normalize(text);
+	const tags = [
+		["gpt", /\bgpt(?:[-\s]\w+)?/i],
+		["gemini", /\bgemini(?:[-\s]\w+)?/i],
+		["claude", /\bclaude(?:[-\s]\w+)?/i],
+		["astra", /\bastra\b/i],
+		["fable", /\bfable(?:[-\s]\w+)?/i],
+	] as const;
+	return tags.flatMap(([tag, pattern]) => (pattern.test(normalized) ? [tag] : []));
+}
+
+export function detectByosanPromptPolicySignals(
+	text: string,
+): z.infer<typeof ByosanPromptPolicySignalsSchema> {
+	const normalized = normalize(text);
+	const progressForbidden =
+		/(途中経過|進捗).{0,24}(報告|更新).{0,24}(禁止|しない|不要)/i.test(
+			normalized,
+		) ||
+		/(do not|don't|never|no).{0,24}progress.{0,16}(update|report)/i.test(
+			normalized,
+		);
+	const progressRequired =
+		/(途中経過|進捗).{0,24}(報告|更新).{0,24}(必須|行う|入れる|共有)/i.test(
+			normalized,
+		) ||
+		/(progress.{0,16}(update|report).{0,20}(required|must)|keep.{0,20}user.{0,20}updated)/i.test(
+			normalized,
+		);
+	const confirmationRequired =
+		/(確認|承認|許可).{0,20}(必須|求める|必要)/i.test(normalized) ||
+		/(ask|require).{0,16}(confirmation|approval|permission)/i.test(normalized);
+	const confirmationBypass =
+		/(取り消し可能|可逆).{0,30}(確認|承認|許可).{0,16}(不要|求めない|なし)/i.test(
+			normalized,
+		) ||
+		/(reversible).{0,30}(without|no).{0,16}(confirmation|approval|permission)/i.test(
+			normalized,
+		);
+
+	return ByosanPromptPolicySignalsSchema.parse({
+		progressUpdates: progressRequired
+			? "required"
+			: progressForbidden
+				? "forbidden"
+				: "unspecified",
+		confirmation: confirmationBypass
+			? "bypass_reversible"
+			: confirmationRequired
+				? "required"
+				: "unspecified",
+	});
+}
+
+function collectFiles(root: string, relativeDir: string): string[] {
+	const absoluteDir = path.join(root, relativeDir);
+	if (!fs.existsSync(absoluteDir)) return [];
+	const files: string[] = [];
+	for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+		const relativePath = path.join(relativeDir, entry.name);
+		if (entry.isDirectory()) {
+			if (["node_modules", ".git", "runs", "logs", "artifacts"].includes(entry.name)) {
+				continue;
+			}
+			files.push(...collectFiles(root, relativePath));
+			continue;
+		}
+		if (/\.(?:ts|js|mjs|cjs)$/.test(entry.name)) files.push(relativePath);
+	}
+	return files;
+}
+
+function recordForSource(
+	sourcePath: string,
+	authority: z.infer<typeof PromptAuthoritySchema>,
+	text: string,
+	contractVersion: string,
+): ByosanPromptSourceRecord {
+	const providerTags = detectProviderTags(text);
+	return ByosanPromptSourceRecordSchema.parse({
+		sourcePath,
+		authority,
+		promptHash: sha256(text),
+		providerProfileApplicability:
+			providerTags.length > 0 ? providerTags : ["all"],
+		contractVersion,
+		signals: detectByosanPromptPolicySignals(text),
+	});
+}
+
+export function discoverByosanPromptInventory(
+	root: string,
+	modelProfile: string,
+	now = new Date(),
+	contractVersion = "prompt_migration_v1",
+): ByosanPromptInventory {
+	const records: ByosanPromptSourceRecord[] = [];
+	const agentsPath = path.join(root, "AGENTS.md");
+	if (fs.existsSync(agentsPath)) {
+		const text = fs.readFileSync(agentsPath, "utf-8");
+		records.push(recordForSource("AGENTS.md", "repository", text, contractVersion));
+	}
+
+	for (const relativePath of collectFiles(root, "src").sort()) {
+		const text = fs.readFileSync(path.join(root, relativePath), "utf-8");
+		if (/role\s*:\s*["']system["']|systemInstruction/i.test(text)) {
+			records.push(recordForSource(relativePath, "system", text, contractVersion));
+		}
+		if (/role\s*:\s*["']developer["']/i.test(text)) {
+			records.push(
+				recordForSource(relativePath, "developer", text, contractVersion),
+			);
+		}
+	}
+
+	records.sort(
+		(left, right) =>
+			left.sourcePath.localeCompare(right.sourcePath) ||
+			left.authority.localeCompare(right.authority),
+	);
+	return ByosanPromptInventorySchema.parse({
+		schemaVersion: "byosan_prompt_inventory_v1",
+		modelProfile,
+		contractVersion,
+		generatedAt: now.toISOString(),
+		records,
+	});
+}
+
+function recordKey(record: ByosanPromptSourceRecord): string {
+	return `${record.sourcePath}:${record.authority}`;
+}
+
+export function diffByosanPromptInventories(
+	previousInput: ByosanPromptInventory,
+	currentInput: ByosanPromptInventory,
+): ByosanPromptInventoryDiff {
+	const previous = ByosanPromptInventorySchema.parse(previousInput);
+	const current = ByosanPromptInventorySchema.parse(currentInput);
+	const previousByKey = new Map(
+		previous.records.map((record) => [recordKey(record), record]),
+	);
+	const currentByKey = new Map(
+		current.records.map((record) => [recordKey(record), record]),
+	);
+	const added = [...currentByKey.keys()]
+		.filter((key) => !previousByKey.has(key))
+		.sort();
+	const removed = [...previousByKey.keys()]
+		.filter((key) => !currentByKey.has(key))
+		.sort();
+	const changed = [...currentByKey.entries()]
+		.filter(([key, record]) => {
+			const previousRecord = previousByKey.get(key);
+			return (
+				previousRecord !== undefined &&
+				(previousRecord.promptHash !== record.promptHash ||
+					previousRecord.contractVersion !== record.contractVersion)
+			);
+		})
+		.map(([key]) => key)
+		.sort();
+	return ByosanPromptInventoryDiffSchema.parse({
+		modelProfileChanged: previous.modelProfile !== current.modelProfile,
+		added,
+		removed,
+		changed,
+	});
+}
+
+function modelProfileMatches(
+	modelProfile: string,
+	applicability: string[],
+): boolean {
+	if (applicability.includes("all")) return true;
+	const normalized = normalize(modelProfile);
+	return applicability.some((tag) => normalized.includes(tag));
+}
+
+export function auditByosanPromptInventory(
+	inventoryInput: ByosanPromptInventory,
+): ByosanPromptMigrationIssue[] {
+	const inventory = ByosanPromptInventorySchema.parse(inventoryInput);
+	const issues: ByosanPromptMigrationIssue[] = [];
+
+	const progressRequired = inventory.records.filter(
+		(record) => record.signals.progressUpdates === "required",
+	);
+	const progressForbidden = inventory.records.filter(
+		(record) => record.signals.progressUpdates === "forbidden",
+	);
+	if (progressRequired.length > 0 && progressForbidden.length > 0) {
+		issues.push({
+			severity: "FAIL",
+			code: "explicit_policy_conflict:progress_updates",
+			details: `required=${progressRequired.map(recordKey).join(",")} forbidden=${progressForbidden.map(recordKey).join(",")}`,
+		});
+	}
+
+	const repositoryRecords = inventory.records.filter(
+		(record) => record.authority === "repository",
+	);
+	for (const repository of repositoryRecords) {
+		for (const local of inventory.records.filter(
+			(record) => record.authority !== "repository",
+		)) {
+			if (
+				repository.signals.progressUpdates !== "unspecified" &&
+				local.signals.progressUpdates !== "unspecified" &&
+				repository.signals.progressUpdates !== local.signals.progressUpdates
+			) {
+				issues.push({
+					severity: "FAIL",
+					code: "repository_authority_conflict:progress_updates",
+					details: `${recordKey(local)} conflicts with ${recordKey(repository)}`,
+				});
+			}
+			if (
+				repository.signals.confirmation !== "unspecified" &&
+				local.signals.confirmation !== "unspecified" &&
+				repository.signals.confirmation !== local.signals.confirmation
+			) {
+				issues.push({
+					severity: "FAIL",
+					code: "repository_authority_conflict:confirmation",
+					details: `${recordKey(local)} conflicts with ${recordKey(repository)}`,
+				});
+			}
+		}
+	}
+
+	const hashes = new Map<string, string[]>();
+	for (const record of inventory.records) {
+		const records = hashes.get(record.promptHash) ?? [];
+		records.push(recordKey(record));
+		hashes.set(record.promptHash, records);
+		if (
+			record.authority !== "repository" &&
+			!modelProfileMatches(
+				inventory.modelProfile,
+				record.providerProfileApplicability,
+			)
+		) {
+			issues.push({
+				severity: "WARN",
+				code: "obsolete_model_specific_patch",
+				details: `${recordKey(record)} applicability=${record.providerProfileApplicability.join(",")} current=${inventory.modelProfile}`,
+			});
+		}
+	}
+	for (const [hash, records] of hashes.entries()) {
+		if (records.length > 1) {
+			issues.push({
+				severity: "WARN",
+				code: "duplicate_prompt_hash",
+				details: `${hash.slice(0, 12)}:${records.join(",")}`,
+			});
+		}
+	}
+
+	for (const policy of ["progressUpdates", "confirmation"] as const) {
+		const bySignal = new Map<string, string[]>();
+		for (const record of inventory.records) {
+			const signal = record.signals[policy];
+			if (signal === "unspecified") continue;
+			const sources = bySignal.get(signal) ?? [];
+			sources.push(recordKey(record));
+			bySignal.set(signal, sources);
+		}
+		for (const [signal, sources] of bySignal.entries()) {
+			if (sources.length > 1) {
+				issues.push({
+					severity: "WARN",
+					code: `semantic_duplicate:${policy}:${signal}`,
+					details: sources.join(","),
+				});
+			}
+		}
+	}
+
+	return issues.map((issue) => ByosanPromptMigrationIssueSchema.parse(issue));
+}
+
+export function auditByosanPromptMigration(
+	previousInput: ByosanPromptInventory | null,
+	currentInput: ByosanPromptInventory,
+): {
+	diff: ByosanPromptInventoryDiff | null;
+	issues: ByosanPromptMigrationIssue[];
+} {
+	const current = ByosanPromptInventorySchema.parse(currentInput);
+	const issues = auditByosanPromptInventory(current);
+	if (!previousInput) return { diff: null, issues };
+	const previous = ByosanPromptInventorySchema.parse(previousInput);
+	const diff = diffByosanPromptInventories(previous, current);
+	if (
+		diff.modelProfileChanged &&
+		diff.added.length > 0 &&
+		diff.removed.length === 0 &&
+		diff.changed.length === 0
+	) {
+		issues.push({
+			severity: "WARN",
+			code: "addition_only_model_migration",
+			details:
+				"model/profile changed but migration only added prompt sources; inspect legacy constraints before adding more",
+		});
+	}
+	return {
+		diff,
+		issues: issues.map((issue) => ByosanPromptMigrationIssueSchema.parse(issue)),
+	};
+}

--- a/src/domain/byosan/prompt_migration.ts
+++ b/src/domain/byosan/prompt_migration.ts
@@ -78,7 +78,9 @@ function detectProviderTags(text: string): string[] {
 		["astra", /\bastra\b/i],
 		["fable", /\bfable(?:[-\s]\w+)?/i],
 	] as const;
-	return tags.flatMap(([tag, pattern]) => (pattern.test(normalized) ? [tag] : []));
+	return tags.flatMap(([tag, pattern]) =>
+		pattern.test(normalized) ? [tag] : [],
+	);
 }
 
 export function detectByosanPromptPolicySignals(
@@ -134,7 +136,11 @@ function collectFiles(root: string, relativeDir: string): string[] {
 	for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
 		const relativePath = path.join(relativeDir, entry.name);
 		if (entry.isDirectory()) {
-			if (["node_modules", ".git", "runs", "logs", "artifacts"].includes(entry.name)) {
+			if (
+				["node_modules", ".git", "runs", "logs", "artifacts"].includes(
+					entry.name,
+				)
+			) {
 				continue;
 			}
 			files.push(...collectFiles(root, relativePath));
@@ -173,13 +179,17 @@ export function discoverByosanPromptInventory(
 	const agentsPath = path.join(root, "AGENTS.md");
 	if (fs.existsSync(agentsPath)) {
 		const text = fs.readFileSync(agentsPath, "utf-8");
-		records.push(recordForSource("AGENTS.md", "repository", text, contractVersion));
+		records.push(
+			recordForSource("AGENTS.md", "repository", text, contractVersion),
+		);
 	}
 
 	for (const relativePath of collectFiles(root, "src").sort()) {
 		const text = fs.readFileSync(path.join(root, relativePath), "utf-8");
 		if (/role\s*:\s*["']system["']|systemInstruction/i.test(text)) {
-			records.push(recordForSource(relativePath, "system", text, contractVersion));
+			records.push(
+				recordForSource(relativePath, "system", text, contractVersion),
+			);
 		}
 		if (/role\s*:\s*["']developer["']/i.test(text)) {
 			records.push(
@@ -383,6 +393,8 @@ export function auditByosanPromptMigration(
 	}
 	return {
 		diff,
-		issues: issues.map((issue) => ByosanPromptMigrationIssueSchema.parse(issue)),
+		issues: issues.map((issue) =>
+			ByosanPromptMigrationIssueSchema.parse(issue),
+		),
 	};
 }

--- a/src/domain/byosan/prompt_migration.ts
+++ b/src/domain/byosan/prompt_migration.ts
@@ -85,13 +85,16 @@ export function detectByosanPromptPolicySignals(
 	text: string,
 ): z.infer<typeof ByosanPromptPolicySignalsSchema> {
 	const normalized = normalize(text);
+	const progressNegated =
+		/(禁止しない|禁止ではない|do not prohibit|not forbidden)/i.test(normalized);
 	const progressForbidden =
-		/(途中経過|進捗).{0,24}(報告|更新).{0,24}(禁止|しない|不要)/i.test(
+		!progressNegated &&
+		(/(途中経過|進捗).{0,24}(報告|更新).{0,24}(禁止|しない|不要)/i.test(
 			normalized,
 		) ||
-		/(do not|don't|never|no).{0,24}progress.{0,16}(update|report)/i.test(
-			normalized,
-		);
+			/(do not|don't|never|no).{0,24}progress.{0,16}(update|report)/i.test(
+				normalized,
+			));
 	const progressRequired =
 		/(途中経過|進捗).{0,24}(報告|更新).{0,24}(必須|行う|入れる|共有)/i.test(
 			normalized,

--- a/src/scripts/audit_prompt_migration.ts
+++ b/src/scripts/audit_prompt_migration.ts
@@ -8,7 +8,10 @@ import {
 
 function argValue(name: string): string | undefined {
 	const prefix = `--${name}=`;
-	return process.argv.slice(2).find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+	return process.argv
+		.slice(2)
+		.find((arg) => arg.startsWith(prefix))
+		?.slice(prefix.length);
 }
 
 const root = process.cwd();

--- a/src/scripts/audit_prompt_migration.ts
+++ b/src/scripts/audit_prompt_migration.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+	ByosanPromptInventorySchema,
+	auditByosanPromptMigration,
+	discoverByosanPromptInventory,
+} from "../domain/byosan/prompt_migration.js";
+
+function argValue(name: string): string | undefined {
+	const prefix = `--${name}=`;
+	return process.argv.slice(2).find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+const root = process.cwd();
+const outputPath = path.resolve(
+	root,
+	argValue("output") ?? "audits/byosan_prompt_inventory.json",
+);
+const reportPath = path.resolve(
+	root,
+	argValue("report") ?? "audits/byosan_prompt_migration.json",
+);
+const previousPath = path.resolve(
+	root,
+	argValue("previous") ?? "audits/byosan_prompt_inventory.json",
+);
+const modelProfile =
+	argValue("model") ??
+	process.env.BYOSAN_MODEL_PROFILE ??
+	process.env.GEMINI_MODEL ??
+	"unconfigured";
+
+const previous =
+	fs.existsSync(previousPath) && previousPath !== outputPath
+		? ByosanPromptInventorySchema.parse(
+				JSON.parse(fs.readFileSync(previousPath, "utf-8")),
+			)
+		: fs.existsSync(outputPath)
+			? ByosanPromptInventorySchema.parse(
+					JSON.parse(fs.readFileSync(outputPath, "utf-8")),
+				)
+			: null;
+const current = discoverByosanPromptInventory(root, modelProfile);
+const audit = auditByosanPromptMigration(previous, current);
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(current, null, 2)}\n`);
+fs.writeFileSync(
+	reportPath,
+	`${JSON.stringify(
+		{
+			schemaVersion: "byosan_prompt_migration_report_v1",
+			previousModelProfile: previous?.modelProfile ?? null,
+			currentModelProfile: current.modelProfile,
+			diff: audit.diff,
+			issues: audit.issues,
+		},
+		null,
+		2,
+	)}\n`,
+);
+
+for (const issue of audit.issues) {
+	const stream = issue.severity === "FAIL" ? console.error : console.warn;
+	stream(`[prompt-migration] ${issue.severity} ${issue.code} ${issue.details}`);
+}
+console.log(
+	`[prompt-migration] inventory=${path.relative(root, outputPath)} records=${current.records.length} model=${current.modelProfile}`,
+);
+console.log(
+	`[prompt-migration] report=${path.relative(root, reportPath)} fail=${audit.issues.filter((issue) => issue.severity === "FAIL").length} warn=${audit.issues.filter((issue) => issue.severity === "WARN").length}`,
+);
+
+if (audit.issues.some((issue) => issue.severity === "FAIL")) process.exit(1);

--- a/tests/byosan_prompt_migration.test.ts
+++ b/tests/byosan_prompt_migration.test.ts
@@ -3,12 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+	type ByosanPromptInventory,
 	auditByosanPromptInventory,
 	auditByosanPromptMigration,
 	detectByosanPromptPolicySignals,
 	diffByosanPromptInventories,
 	discoverByosanPromptInventory,
-	type ByosanPromptInventory,
 } from "../src/domain/byosan/prompt_migration.js";
 
 function inventory(
@@ -33,7 +33,10 @@ function record(
 	return {
 		sourcePath,
 		authority,
-		promptHash: sourcePath.padEnd(64, "0").slice(0, 64).replaceAll(/[^a-f0-9]/g, "a"),
+		promptHash: sourcePath
+			.padEnd(64, "0")
+			.slice(0, 64)
+			.replaceAll(/[^a-f0-9]/g, "a"),
 		providerProfileApplicability,
 		contractVersion: "prompt_migration_v1",
 		signals: {
@@ -49,20 +52,26 @@ describe("byosan prompt migration audit", () => {
 			record("AGENTS.md", "repository", "required"),
 			record("src/agent.ts", "system", "forbidden"),
 		]);
-		const codes = auditByosanPromptInventory(current).map((issue) => issue.code);
+		const codes = auditByosanPromptInventory(current).map(
+			(issue) => issue.code,
+		);
 		expect(codes).toContain("explicit_policy_conflict:progress_updates");
 		expect(codes).toContain("repository_authority_conflict:progress_updates");
 	});
 
 	test("signal detector recognizes the migration failure fixture", () => {
 		expect(
-			detectByosanPromptPolicySignals("長時間runでは進捗更新を必須として共有する").progressUpdates,
+			detectByosanPromptPolicySignals(
+				"長時間runでは進捗更新を必須として共有する",
+			).progressUpdates,
 		).toBe("required");
 		expect(
-			detectByosanPromptPolicySignals("途中経過の報告は禁止しない").progressUpdates,
+			detectByosanPromptPolicySignals("途中経過の報告は禁止しない")
+				.progressUpdates,
 		).not.toBe("forbidden");
 		expect(
-			detectByosanPromptPolicySignals("途中経過の報告を禁止する").progressUpdates,
+			detectByosanPromptPolicySignals("途中経過の報告を禁止する")
+				.progressUpdates,
 		).toBe("forbidden");
 	});
 
@@ -85,9 +94,9 @@ describe("byosan prompt migration audit", () => {
 		const current = inventory("gemini-3", [
 			record("src/legacy.ts", "system", "unspecified", ["gpt"]),
 		]);
-		expect(auditByosanPromptInventory(current).map((issue) => issue.code)).toContain(
-			"obsolete_model_specific_patch",
-		);
+		expect(
+			auditByosanPromptInventory(current).map((issue) => issue.code),
+		).toContain("obsolete_model_specific_patch");
 	});
 
 	test("inventory discovery records repository and system prompt hashes without raw prompt text", () => {

--- a/tests/byosan_prompt_migration.test.ts
+++ b/tests/byosan_prompt_migration.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	auditByosanPromptInventory,
+	auditByosanPromptMigration,
+	detectByosanPromptPolicySignals,
+	diffByosanPromptInventories,
+	discoverByosanPromptInventory,
+	type ByosanPromptInventory,
+} from "../src/domain/byosan/prompt_migration.js";
+
+function inventory(
+	modelProfile: string,
+	records: ByosanPromptInventory["records"],
+): ByosanPromptInventory {
+	return {
+		schemaVersion: "byosan_prompt_inventory_v1",
+		modelProfile,
+		contractVersion: "prompt_migration_v1",
+		generatedAt: "2026-09-07T03:00:00.000Z",
+		records,
+	};
+}
+
+function record(
+	sourcePath: string,
+	authority: "repository" | "system" | "developer",
+	progressUpdates: "required" | "forbidden" | "unspecified",
+	providerProfileApplicability = ["all"],
+): ByosanPromptInventory["records"][number] {
+	return {
+		sourcePath,
+		authority,
+		promptHash: sourcePath.padEnd(64, "0").slice(0, 64).replaceAll(/[^a-f0-9]/g, "a"),
+		providerProfileApplicability,
+		contractVersion: "prompt_migration_v1",
+		signals: {
+			progressUpdates,
+			confirmation: "unspecified",
+		},
+	};
+}
+
+describe("byosan prompt migration audit", () => {
+	test("detects explicit progress-update contradiction", () => {
+		const current = inventory("gemini-3", [
+			record("AGENTS.md", "repository", "required"),
+			record("src/agent.ts", "system", "forbidden"),
+		]);
+		const codes = auditByosanPromptInventory(current).map((issue) => issue.code);
+		expect(codes).toContain("explicit_policy_conflict:progress_updates");
+		expect(codes).toContain("repository_authority_conflict:progress_updates");
+	});
+
+	test("signal detector recognizes the migration failure fixture", () => {
+		expect(
+			detectByosanPromptPolicySignals("長時間runでは進捗更新を必須として共有する").progressUpdates,
+		).toBe("required");
+		expect(
+			detectByosanPromptPolicySignals("途中経過の報告は禁止しない").progressUpdates,
+		).not.toBe("forbidden");
+		expect(
+			detectByosanPromptPolicySignals("途中経過の報告を禁止する").progressUpdates,
+		).toBe("forbidden");
+	});
+
+	test("model change that only adds prompt sources is warned", () => {
+		const previous = inventory("gemini-2", [
+			record("AGENTS.md", "repository", "required"),
+		]);
+		const current = inventory("gemini-3", [
+			record("AGENTS.md", "repository", "required"),
+			record("src/new_prompt.ts", "system", "required"),
+		]);
+		const audit = auditByosanPromptMigration(previous, current);
+		expect(audit.diff?.modelProfileChanged).toBe(true);
+		expect(audit.issues.map((issue) => issue.code)).toContain(
+			"addition_only_model_migration",
+		);
+	});
+
+	test("obsolete model-specific prompt sources are classified", () => {
+		const current = inventory("gemini-3", [
+			record("src/legacy.ts", "system", "unspecified", ["gpt"]),
+		]);
+		expect(auditByosanPromptInventory(current).map((issue) => issue.code)).toContain(
+			"obsolete_model_specific_patch",
+		);
+	});
+
+	test("inventory discovery records repository and system prompt hashes without raw prompt text", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "yt3-prompt-audit-"));
+		try {
+			fs.mkdirSync(path.join(root, "src"), { recursive: true });
+			fs.writeFileSync(
+				path.join(root, "AGENTS.md"),
+				"進捗更新を必須として共有する",
+			);
+			fs.writeFileSync(
+				path.join(root, "src", "agent.ts"),
+				'const messages = [{ role: "system", content: "test" }];',
+			);
+			const found = discoverByosanPromptInventory(
+				root,
+				"gemini-3",
+				new Date("2026-09-07T03:00:00Z"),
+			);
+			expect(found.records.map((item) => item.sourcePath)).toEqual([
+				"AGENTS.md",
+				"src/agent.ts",
+			]);
+			expect(found.records.every((item) => item.promptHash.length === 64)).toBe(
+				true,
+			);
+			expect(JSON.stringify(found)).not.toContain('"content":"test"');
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("inventory diff separates added removed and changed sources", () => {
+		const previous = inventory("gemini-2", [
+			record("AGENTS.md", "repository", "required"),
+			record("src/removed.ts", "system", "unspecified"),
+		]);
+		const changed = {
+			...record("AGENTS.md", "repository", "required"),
+			promptHash: "b".repeat(64),
+		};
+		const current = inventory("gemini-3", [
+			changed,
+			record("src/added.ts", "system", "unspecified"),
+		]);
+		const diff = diffByosanPromptInventories(previous, current);
+		expect(diff.added).toEqual(["src/added.ts:system"]);
+		expect(diff.removed).toEqual(["src/removed.ts:system"]);
+		expect(diff.changed).toEqual(["AGENTS.md:repository"]);
+	});
+});


### PR DESCRIPTION
Closes #110

- inventory repository/system/developer prompt sources with hashes and model applicability
- detect explicit policy conflicts, repository-authority conflicts, duplicates, and obsolete model-specific patches
- diff prompt inventories across model/profile changes
- warn when a migration only adds prompt sources without removing/changing legacy constraints
- expose the canonical `task audit:prompt-migration` entry point
- add deterministic conflict, negation, obsolete-patch, inventory, and diff tests