### PR TITLE
ci: add dedicated self-hosted runtime verification

### DIFF
--- a/.github/workflows/self-hosted-runtime.yml
+++ b/.github/workflows/self-hosted-runtime.yml
@@ -1,0 +1,52 @@
+name: Self-hosted runtime verify
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-verify:
+    runs-on: [self-hosted, Linux, X64, yt3-runtime]
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner prerequisites
+        run: |
+          set -euo pipefail
+          uname -a
+          command -v bun
+          command -v task
+          command -v ffmpeg
+          command -v uv
+          command -v python3
+          bun --version
+          task --version
+          ffmpeg -version | head -n 1
+          uv --version
+          python3 --version
+
+      - name: Install repository dependencies
+        run: task setup
+
+      - name: Run repository merge gate
+        run: task check:merge
+
+      - name: Run non-publishing runtime smoke
+        run: task byosan:runtime-smoke
+
+      - name: Upload runtime evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: yt3-self-hosted-runtime-evidence
+          path: .artifacts/byosan-runtime-smoke/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/self-hosted-runtime.yml
+++ b/.github/workflows/self-hosted-runtime.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   runtime-verify:
+    if: github.repository == 'KAFKA2306/yt3' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, Linux, X64, yt3-runtime]
     timeout-minutes: 30
 
@@ -17,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Verify runner prerequisites
         run: |


### PR DESCRIPTION
Closes #114 partially.

Adds a manually-triggered self-hosted runtime workflow for the YT3 target runtime.

Design:
- keep the existing merge gate on `ubuntu-latest`
- target `[self-hosted, Linux, X64, yt3-runtime]`
- verify Bun/Task/ffmpeg/uv/Python on the actual machine
- run canonical `Taskfile.yml` commands only
- run `task setup`, `task check:merge`, `task byosan:runtime-smoke`
- never invoke publication
- upload runtime-smoke evidence when available

Remaining runtime verification: register the physical Linux/WSL runner with label `yt3-runtime`, then manually dispatch this workflow once and inspect the run/artifact.